### PR TITLE
Add Zenn article link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 > [!Warning]
 > 初期バージョンのため、使いながら適宜改善していく予定
 
+📝 **関連記事**  
+**[Claude Code + Kiro式「仕様書駆動開発」で小規模なプロダクト開発を効率化する](https://zenn.dev/gotalab/articles/3db0621ce3d6d2)** - Zenn記事
 
 Claude CodeのSlash CommandsとCLAUDE.mdを使用して、Kiro IDEに組み込まれているSpec-Driven Developmentを実践するためのプロジェクト。Kiroでの実際の仕様書駆動開発の流れをディレクトリ構成も含めてほぼそのまま再現している。
 


### PR DESCRIPTION
## Summary
- Adds a prominent link to the Zenn article about Claude Code + Kiro spec-driven development in the README
- Improves visibility and accessibility of related documentation

## Test plan
- [x] Verify README displays correctly
- [x] Check that link works and points to correct article
- [x] Ensure formatting is consistent with existing style

🤖 Generated with [Claude Code](https://claude.ai/code)