### PR TITLE
Fix slash command syntax in spec command files

### DIFF
--- a/.claude/commands/kiro/spec-design.md
+++ b/.claude/commands/kiro/spec-design.md
@@ -358,10 +358,10 @@ This command now implements interactive approval:
 1. **Requirements Review Prompt**: Automatically prompts user to confirm requirements review
 2. **Auto-approval**: Updates spec.json automatically when user confirms with 'y'
 3. **Design Generation**: Proceeds immediately after approval
-4. **Next Phase**: Design is generated and ready for interactive approval by `/spec-tasks`
+4. **Next Phase**: Design is generated and ready for interactive approval by `/kiro:spec-tasks`
 
 ### Design Review for Next Phase
-After generating design.md, the next phase (`/spec-tasks $ARGUMENTS`) will use similar interactive approval:
+After generating design.md, the next phase (`/kiro:spec-tasks $ARGUMENTS`) will use similar interactive approval:
 
 **Preview of next interaction**:
 ```

--- a/.claude/commands/kiro/spec-init.md
+++ b/.claude/commands/kiro/spec-init.md
@@ -84,11 +84,11 @@ Create initial metadata with approval tracking and project description:
 $ARGUMENTS
 
 ## Requirements
-<!-- Detailed user stories will be generated in /spec-requirements phase -->
+<!-- Detailed user stories will be generated in /kiro:spec-requirements phase -->
 
 ---
 **STATUS**: Ready for requirements generation
-**NEXT STEP**: Run `/spec-requirements {feature-name}` to generate detailed requirements
+**NEXT STEP**: Run `/kiro:spec-requirements {feature-name}` to generate detailed requirements
 ```
 
 #### design.md (Empty Template)
@@ -122,12 +122,12 @@ Add the new spec to the active specifications list with the generated feature na
 Follow the proper spec-driven development workflow with **interactive approval**:
 
 **Streamlined workflow with interactive approval:**
-1. **Generate requirements**: `/spec-requirements {feature-name}`
-2. **Generate design with interactive approval**: `/spec-design {feature-name}`
+1. **Generate requirements**: `/kiro:spec-requirements {feature-name}`
+2. **Generate design with interactive approval**: `/kiro:spec-design {feature-name}`
    - Will prompt: "requirements.mdをレビューしましたか？ [y/N]"
    - If 'y': Auto-approves requirements and generates design
    - If 'N': Stops for manual review
-3. **Generate tasks with interactive approval**: `/spec-tasks {feature-name}`
+3. **Generate tasks with interactive approval**: `/kiro:spec-tasks {feature-name}`
    - Will prompt for both requirements and design review
    - Auto-approves both phases when confirmed
 4. **Start implementation**: After all phases are complete

--- a/.claude/commands/kiro/spec-requirements.md
+++ b/.claude/commands/kiro/spec-requirements.md
@@ -126,11 +126,11 @@ Generate the requirements document content ONLY. Do not include any review or ap
 The following is for Claude Code conversation only - NOT for the generated document:
 
 ### Next Phase Uses Interactive Approval
-After generating requirements.md, the next phase (`/spec-design $ARGUMENTS`) will use interactive approval:
+After generating requirements.md, the next phase (`/kiro:spec-design $ARGUMENTS`) will use interactive approval:
 
 **Next interaction will be**:
 ```
-/spec-design feature-name
+/kiro:spec-design feature-name
 # → "requirements.mdをレビューしましたか？ [y/N]"
 # → If 'y': Auto-approval + design generation
 # → If 'N': Stop and request review first
@@ -162,7 +162,7 @@ If needed, you can still manually approve by updating `.kiro/specs/$ARGUMENTS/sp
 }
 ```
 
-**Recommended**: Use the interactive approval in `/spec-design $ARGUMENTS` for better user experience.
+**Recommended**: Use the interactive approval in `/kiro:spec-design $ARGUMENTS` for better user experience.
 
 ## Instructions
 


### PR DESCRIPTION
## Summary
- Fixed incorrect slash command references missing the `kiro:` namespace
- Updated `/spec-design` → `/kiro:spec-design`
- Updated `/spec-requirements` → `/kiro:spec-requirements`  
- Updated `/spec-tasks` → `/kiro:spec-tasks`

## Changes Made
- `.claude/commands/kiro/spec-design.md`: Fixed 2 command references
- `.claude/commands/kiro/spec-init.md`: Fixed 5 command references
- `.claude/commands/kiro/spec-requirements.md`: Fixed 3 command references

## Test Plan
- [x] Verified all slash command references now use proper `kiro:` namespace
- [x] Confirmed command files follow Claude Code namespacing conventions
- [x] Checked consistency across all command documentation

Fixes #28

🤖 Generated with [Claude Code](https://claude.ai/code)