### PR TITLE
docs: add alpha version info and improve language table

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@
 
 # cc-sdd: High-quality spec-driven development for AI coding agents
 
-✨ **Transform Claude Code / Codex / Gemini CLI / Cursor / GitHub Copilot / Qwen Code from prototype to production-ready development**
-
-Customize all spec and steering templates with a few edits—tailor the generated requirements, design docs, tasks (plan docs), and project memory to your team before the agent ever runs.
-
 <!-- npm badges -->
 [![npm version](https://img.shields.io/npm/v/cc-sdd?logo=npm)](https://www.npmjs.com/package/cc-sdd?activeTab=readme)
 [![install size](https://packagephobia.com/badge?p=cc-sdd)](https://packagephobia.com/result?p=cc-sdd)
 [![license: MIT](https://img.shields.io/badge/license-MIT-green.svg)](tools/cc-sdd/LICENSE)
+
+✨ **Transform Claude Code / Codex / Gemini CLI / Cursor / GitHub Copilot / Qwen Code from prototype to production-ready development**
+
+Customize all spec and steering templates with a few edits—tailor the generated requirements, design docs, tasks (plan docs), and project memory to your team before the agent ever runs.
+
 
 
 One command installs **AI-DLC** (AI-Driven Development Life Cycle) with **SDD** (Spec-Driven Development) workflows for Claude Code, Cursor IDE, Gemini CLI, Codex CLI, GitHub Copilot, and Qwen Code.
@@ -22,16 +23,19 @@ One command installs **AI-DLC** (AI-Driven Development Life Cycle) with **SDD** 
 # Basic installation (default: Claude Code)
 npx cc-sdd@latest
 
+# Alpha version with major updates (v2.0.0-alpha.1)
+npx cc-sdd@next
+
 # With language: --lang en|ja|zh-TW|zh|es|pt|de|fr|ru|it|ko|ar
-# With OS: --os mac | --os windows | --os linux (if auto-detection fails)
-npx cc-sdd@latest --lang ja --os mac
+npx cc-sdd@latest --lang ja
 
 # With different agents: gemini, cursor, codex, copilot, qwen
-npx cc-sdd@latest --gemini
-npx cc-sdd@latest --cursor
-npx cc-sdd@latest --codex
-npx cc-sdd@latest --copilot
-npx cc-sdd@latest --qwen
+npx cc-sdd@latest --claude    # or @next for latest alpha
+npx cc-sdd@latest --gemini    # or @next for latest alpha
+npx cc-sdd@latest --cursor    # or @next for latest alpha
+npx cc-sdd@next --codex       # Requires alpha version
+npx cc-sdd@next --copilot     # Requires alpha version
+npx cc-sdd@latest --qwen      # or @next for latest alpha
 
 # Ready to go! Your chosen agent can now run `/kiro:spec-init <what-to-build>` and unlock the full SDD workflow
 ```
@@ -64,18 +68,22 @@ After running cc-sdd, you'll have:
 
 ## 🌐 Supported Languages
 
-- English (`en`)
-- Japanese (`ja`)
-- Traditional Chinese (`zh-TW`)
-- Chinese (`zh`)
-- Spanish (`es`)
-- Portuguese (`pt`)
-- German (`de`)
-- French (`fr`)
-- Russian (`ru`)
-- Italian (`it`)
-- Korean (`ko`)
-- Arabic (`ar`)
+| Language | Code |  |
+|----------|------|------|
+| English | `en` | 🇬🇧 |
+| Japanese | `ja` | 🇯🇵 |
+| Traditional Chinese | `zh-TW` | 🇹🇼 |
+| Simplified Chinese | `zh` | 🇨🇳 |
+| Spanish | `es` | 🇪🇸 |
+| Portuguese | `pt` | 🇵🇹 |
+| German | `de` | 🇩🇪 |
+| French | `fr` | 🇫🇷 |
+| Russian | `ru` | 🇷🇺 |
+| Italian | `it` | 🇮🇹 |
+| Korean | `ko` | 🇰🇷 |
+| Arabic | `ar` | 🇸🇦 |
+
+**Usage**: `npx cc-sdd@latest --lang <code>` (e.g., `--lang ja` for Japanese)
 
 
 ---

--- a/tools/cc-sdd/README.md
+++ b/tools/cc-sdd/README.md
@@ -25,33 +25,41 @@ Brings **AI-DLC (AI Driven Development Lifecycle)** to Claude Code, Cursor IDE, 
 # Basic installation (defaults: English docs, Claude Code agent)
 npx cc-sdd@latest
 
+# Alpha version with major updates (v2.0.0-alpha.1)
+npx cc-sdd@next
+
 # With language options (default: --lang en)
 npx cc-sdd@latest --lang ja    # Japanese
 npx cc-sdd@latest --lang zh-TW # Traditional Chinese
 # Supported languages: en, ja, zh-TW, zh, es, pt, de, fr, ru, it, ko, ar
 
 # With agent options (default: claude-code / --claude)
-npx cc-sdd@latest --gemini --lang ja # Gemini CLI
-npx cc-sdd@latest --cursor --lang ja # Cursor IDE
-npx cc-sdd@latest --codex --lang ja # Codex CLI (prompt set)
-npx cc-sdd@latest --copilot --lang ja # GitHub Copilot chat prompts
-npx cc-sdd@latest --qwen --lang ja # Qwen Code
+npx cc-sdd@latest --claude --lang ja    # or @next for latest alpha
+npx cc-sdd@latest --gemini --lang ja    # or @next for latest alpha
+npx cc-sdd@latest --cursor --lang ja    # or @next for latest alpha
+npx cc-sdd@next --codex --lang ja       # Requires alpha version
+npx cc-sdd@next --copilot --lang ja     # Requires alpha version
+npx cc-sdd@latest --qwen --lang ja      # or @next for latest alpha
 ```
 
 ## 🌐 Supported Languages
 
-- English (`en`)
-- Japanese (`ja`)
-- Traditional Chinese (`zh-TW`)
-- Chinese (`zh`)
-- Spanish (`es`)
-- Portuguese (`pt`)
-- German (`de`)
-- French (`fr`)
-- Russian (`ru`)
-- Italian (`it`)
-- Korean (`ko`)
-- Arabic (`ar`)
+| Language | Code |  |
+|----------|------|------|
+| English | `en` | 🇬🇧 |
+| Japanese | `ja` | 🇯🇵 |
+| Traditional Chinese | `zh-TW` | 🇹🇼 |
+| Simplified Chinese | `zh` | 🇨🇳 |
+| Spanish | `es` | 🇪🇸 |
+| Portuguese | `pt` | 🇵🇹 |
+| German | `de` | 🇩🇪 |
+| French | `fr` | 🇫🇷 |
+| Russian | `ru` | 🇷🇺 |
+| Italian | `it` | 🇮🇹 |
+| Korean | `ko` | 🇰🇷 |
+| Arabic | `ar` | 🇸🇦 |
+
+**Usage**: `npx cc-sdd@latest --lang <code>` (e.g., `--lang ja` for Japanese)
 
 ## ✨ Quick Start
 

--- a/tools/cc-sdd/README_ja.md
+++ b/tools/cc-sdd/README_ja.md
@@ -25,18 +25,40 @@ Claude Code、Cursor IDE、Gemini CLI、Codex CLI、GitHub Copilot、Qwen Code�
 # 基本インストール（デフォルト: 英語、Claude Code）
 npx cc-sdd@latest
 
+# アルファ版（大幅アップデート版 v2.0.0-alpha.1）
+npx cc-sdd@next
+
 # 言語オプション（デフォルト: --lang en）
 npx cc-sdd@latest --lang ja    # 日本語
 npx cc-sdd@latest --lang zh-TW # 繁体字中国語
-# 対応言語: en, ja, zh-TW, zh, es, pt, de, fr, ru, it, ko, ar
 
 # エージェントオプション（デフォルト: claude-code / --claude）
-npx cc-sdd@latest --gemini --lang ja # Gemini CLI用
-npx cc-sdd@latest --cursor --lang ja # Cursor IDE用
-npx cc-sdd@latest --codex --lang ja # Codex CLI（プロンプト）用
-npx cc-sdd@latest --copilot --lang ja # GitHub Copilot用プロンプト
-npx cc-sdd@latest --qwen --lang ja # Qwen Code用
+npx cc-sdd@latest --claude --lang ja    # または @next で最新アルファ版
+npx cc-sdd@latest --gemini --lang ja    # または @next で最新アルファ版
+npx cc-sdd@latest --cursor --lang ja    # または @next で最新アルファ版
+npx cc-sdd@next --codex --lang ja       # アルファ版必須
+npx cc-sdd@next --copilot --lang ja     # アルファ版必須
+npx cc-sdd@latest --qwen --lang ja      # または @next で最新アルファ版
 ```
+
+## 🌐 対応言語
+
+| 言語 | コード |  |
+|------|--------|------|
+| 英語 | `en` | 🇬🇧 |
+| 日本語 | `ja` | 🇯🇵 |
+| 繁体字中国語 | `zh-TW` | 🇹🇼 |
+| 簡体字中国語 | `zh` | 🇨🇳 |
+| スペイン語 | `es` | 🇪🇸 |
+| ポルトガル語 | `pt` | 🇵🇹 |
+| ドイツ語 | `de` | 🇩🇪 |
+| フランス語 | `fr` | 🇫🇷 |
+| ロシア語 | `ru` | 🇷🇺 |
+| イタリア語 | `it` | 🇮🇹 |
+| 韓国語 | `ko` | 🇰🇷 |
+| アラビア語 | `ar` | 🇸🇦 |
+
+**使用方法**: `npx cc-sdd@latest --lang <コード>` (例: 日本語の場合は `--lang ja`)
 
 ## ✨ クイックスタート
 

--- a/tools/cc-sdd/README_zh-TW.md
+++ b/tools/cc-sdd/README_zh-TW.md
@@ -25,18 +25,40 @@
 # 基本安裝（預設：英文文件，Claude Code 代理）
 npx cc-sdd@latest
 
+# Alpha 版本（重大更新版 v2.0.0-alpha.1）
+npx cc-sdd@next
+
 # 語言選項（預設：--lang en）
 npx cc-sdd@latest --lang zh-TW # 繁體中文
 npx cc-sdd@latest --lang ja    # 日語
-# 支援語言：en, ja, zh-TW, zh, es, pt, de, fr, ru, it, ko, ar
 
 # 代理選項（預設：claude-code / --claude）
-npx cc-sdd@latest --gemini --lang zh-TW # Gemini CLI 用
-npx cc-sdd@latest --cursor --lang zh-TW # Cursor IDE 用
-npx cc-sdd@latest --codex --lang zh-TW # Codex CLI（提示集）用
-npx cc-sdd@latest --copilot --lang zh-TW # GitHub Copilot 用提示
-npx cc-sdd@latest --qwen --lang zh-TW # Qwen Code 用
+npx cc-sdd@latest --claude --lang zh-TW    # 或 @next 取得最新 alpha
+npx cc-sdd@latest --gemini --lang zh-TW    # 或 @next 取得最新 alpha
+npx cc-sdd@latest --cursor --lang zh-TW    # 或 @next 取得最新 alpha
+npx cc-sdd@next --codex --lang zh-TW       # 需要 alpha 版本
+npx cc-sdd@next --copilot --lang zh-TW     # 需要 alpha 版本
+npx cc-sdd@latest --qwen --lang zh-TW      # 或 @next 取得最新 alpha
 ```
+
+## 🌐 支援語言
+
+| 語言 | 代碼 |  |
+|------|------|------|
+| 英語 | `en` | 🇬🇧 |
+| 日語 | `ja` | 🇯🇵 |
+| 繁體中文 | `zh-TW` | 🇹🇼 |
+| 簡體中文 | `zh` | 🇨🇳 |
+| 西班牙語 | `es` | 🇪🇸 |
+| 葡萄牙語 | `pt` | 🇵🇹 |
+| 德語 | `de` | 🇩🇪 |
+| 法語 | `fr` | 🇫🇷 |
+| 俄語 | `ru` | 🇷🇺 |
+| 義大利語 | `it` | 🇮🇹 |
+| 韓語 | `ko` | 🇰🇷 |
+| 阿拉伯語 | `ar` | 🇸🇦 |
+
+**使用方法**: `npx cc-sdd@latest --lang <代碼>` (例如繁體中文使用 `--lang zh-TW`)
 
 ## ✨ 快速開始
 


### PR DESCRIPTION
## Summary
- Added v2.0.0-alpha.1 installation instructions using `@next`
- Clarified that Codex CLI and GitHub Copilot require alpha version
- Improved language support section with visual table and flag emojis
- Added usage examples for language selection

## Changes
- Updated 4 README files (root + 3 language versions)
- Converted bullet list to table format for better readability
- Added `npx cc-sdd@next` examples throughout documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)