### PR TITLE
feat: add windsurf agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.0-alpha.3] - 2025-10-22
+
+### Added
+- Windsurf IDE agent definition, manifest, and workflow templates so `npx cc-sdd@next --windsurf` installs `.windsurf/workflows/` and AGENTS.md alongside shared settings.
+- `realManifestWindsurf` vitest coverage that exercises dry-run and apply flows across macOS/Linux runtimes.
+- `--windsurf` CLI alias support and accompanying argument parser tests.
+
+### Changed
+- Updated completion guides and recommended model messaging to include Windsurf-specific guidance.
+- Refreshed root README, `tools/cc-sdd/README*`, and `docs/README/README_{en,ja,zh-TW}.md` with Windsurf setup instructions and manual QA steps.
+
 ## [2.0.0-alpha.2] - 2025-10-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,23 +9,23 @@
 [![install size](https://packagephobia.com/badge?p=cc-sdd)](https://packagephobia.com/result?p=cc-sdd)
 [![license: MIT](https://img.shields.io/badge/license-MIT-green.svg)](tools/cc-sdd/LICENSE)
 
-✨ **Transform Claude Code / Codex / Gemini CLI / Cursor / GitHub Copilot / Qwen Code from prototype to production-ready development, while customizing every spec and steering template so the generated requirements, design docs, tasks, and project memory match your team's workflow from day one.**
+✨ **Transform Claude Code / Codex / Cursor / Gemini CLI / GitHub Copilot / Qwen Code / Windsurf from prototype to production-ready development, while customizing every spec and steering template so the generated requirements, design docs, tasks, and project memory match your team's workflow from day one.**
 
 ## 🚀 Quick Start
-One command installs **AI-DLC** (AI-Driven Development Life Cycle) with **SDD** (Spec-Driven Development) workflows for Claude Code, Cursor IDE, Gemini CLI, Codex CLI, GitHub Copilot, and Qwen Code.
+One command installs **AI-DLC** (AI-Driven Development Life Cycle) with **SDD** (Spec-Driven Development) workflows for Claude Code, Cursor IDE, Gemini CLI, Codex CLI, GitHub Copilot, Qwen Code, and Windsurf IDE.
 It also scaffolds team-aligned templates—requirements, design reviews, task plans, and steering docs—so every slash command outputs documentation that fits your existing approval process.
 
 ```bash
 # Basic installation (default: Claude Code)
 npx cc-sdd@latest
 
-# Alpha version with major updates (v2.0.0-alpha.2)
+# Alpha version with major updates (v2.0.0-alpha.3)
 npx cc-sdd@next
 
 # With language: --lang en|ja|zh-TW|zh|es|pt|de|fr|ru|it|ko|ar
 npx cc-sdd@latest --lang ja
 
-# With different agents: gemini, cursor, codex, copilot, qwen
+# With different agents: gemini, cursor, codex, copilot, qwen, windsurf
 npx cc-sdd@latest --claude    # or @next for latest alpha
 npx cc-sdd@next --claude-agent    # Installs Claude Code SubAgents (requires @next)
 npx cc-sdd@latest --gemini    # or @next for latest alpha
@@ -33,6 +33,7 @@ npx cc-sdd@latest --cursor    # or @next for latest alpha
 npx cc-sdd@next --codex       # Requires alpha version
 npx cc-sdd@next --copilot     # Requires alpha version
 npx cc-sdd@latest --qwen      # or @next for latest alpha
+npx cc-sdd@next --windsurf    # Requires alpha version (Windsurf workflows)
 
 # Ready to go! Your chosen agent can now run `/kiro:spec-init <what-to-build>` and unlock the full SDD workflow
 ```
@@ -61,6 +62,7 @@ After running cc-sdd, you'll have:
 | GitHub Copilot Chat | `--copilot`, `--github-copilot` | `.github/prompts/`, `{{KIRO_DIR}}/settings/`, `AGENTS.md` |
 | Gemini CLI | `--gemini-cli`, `--gemini` | `.gemini/commands/kiro/`, `{{KIRO_DIR}}/settings/`, `GEMINI.md` |
 | Qwen Code | `--qwen-code`, `--qwen` | `.qwen/commands/kiro/`, `{{KIRO_DIR}}/settings/`, `QWEN.md` |
+| Windsurf IDE | `--windsurf` | `.windsurf/workflows/`, `{{KIRO_DIR}}/settings/`, `AGENTS.md` — requires `cc-sdd@next` |
 
 *Claude Code remains the default agent when no flag is supplied.*
 
@@ -88,9 +90,9 @@ After running cc-sdd, you'll have:
 
 ## About
 
-Brings to Claude Code, Cursor IDE, Gemini CLI, Codex CLI, GitHub Copilot, and Qwen Code your project context, Project Memory (steering) and development patterns: **requirements → design → tasks → implementation**. **Kiro IDE compatible** — Reuse Kiro-style SDD specs and workflows seamlessly.
+Brings to Claude Code, Cursor IDE, Gemini CLI, Codex CLI, GitHub Copilot, Qwen Code, and Windsurf your project context, Project Memory (steering) and development patterns: **requirements → design → tasks → implementation**. **Kiro IDE compatible** — Reuse Kiro-style SDD specs and workflows seamlessly.
 
-ワンライナーで **AI-DLC（AI-Driven Development Life Cycle）** と **Spec-Driven Development（仕様駆動開発）** のワークフローを導入。プロジェクト直下に **11個のSlash / Prompt Commands** 一式と設定ファイル（Claude Code用 **CLAUDE.md** / Cursor IDE・Codex CLI・GitHub Copilot用 **AGENTS.md** / Gemini CLI用 **GEMINI.md**）を配置、プロジェクトの文脈と開発パターン（**要件 → 設計 → タスク → 実装**）、**プロジェクトメモリ（ステアリング）** を含む。
+ワンライナーで **AI-DLC（AI-Driven Development Life Cycle）** と **Spec-Driven Development（仕様駆動開発）** のワークフローを導入。プロジェクト直下に **11個のSlash / Prompt Commands** 一式と設定ファイル（Claude Code用 **CLAUDE.md** / Cursor IDE・Codex CLI・GitHub Copilot・Windsurf用 **AGENTS.md** / Gemini CLI用 **GEMINI.md**）を配置、プロジェクトの文脈と開発パターン（**要件 → 設計 → タスク → 実装**）、**プロジェクトメモリ（ステアリング）** を含む。
 
 📝 **関連記事**  
 **[Kiroの仕様書駆動開発プロセスをClaude Codeで徹底的に再現した](https://zenn.dev/gotalab/articles/3db0621ce3d6d2)** - Zenn記事
@@ -190,7 +192,7 @@ For detailed documentation, installation instructions, and usage examples, see:
 cc-sdd/
 ├── tools/cc-sdd/              # Main cc-sdd NPM package
 │   ├── src/                   # TypeScript source code
-│   ├── templates/             # Agent templates (Claude Code, Cursor IDE, Gemini CLI, Codex CLI, GitHub Copilot, Qwen Code)
+│   ├── templates/             # Agent templates (Claude Code, Cursor IDE, Gemini CLI, Codex CLI, GitHub Copilot, Qwen Code, Windsurf)
 │   ├── package.json           # Package configuration
 │   └── README.md              # Tool documentation
 ├── docs/                      # Documentation

--- a/docs/README/README_en.md
+++ b/docs/README/README_en.md
@@ -17,7 +17,7 @@ A comprehensive Spec-Driven Development toolset supporting Claude Code, Cursor, 
 
 ## Overview
 
-This project provides a toolset for efficient Spec-Driven Development using Slash Commands across multiple AI platforms (Claude Code, Cursor, Gemini CLI, Codex CLI). By using appropriate commands for each development phase, you can achieve a systematic and high-quality development process regardless of your preferred platform.
+This project provides a toolset for efficient Spec-Driven Development using Slash Commands across multiple AI platforms (Claude Code, Cursor, Gemini CLI, Codex CLI, GitHub Copilot, Qwen Code, Windsurf). By using appropriate commands for each development phase, you can achieve a systematic and high-quality development process regardless of your preferred platform.
 
 ## Setup
 
@@ -27,9 +27,12 @@ Copy the appropriate directory based on your AI development platform:
 
 #### Platform-Specific Directories
 - **🤖 Claude Code**: `.claude/commands/` - Slash Commands definitions
+- **🧠 Codex CLI**: `.codex/prompts/` - OpenAI Codex prompt definitions
 - **🔮 Cursor**: `.cursor/commands/` - Cursor command definitions  
 - **⚡ Gemini CLI**: `.gemini/commands/` - TOML configuration files
-- **🧠 Codex CLI**: `.codex/commands/` - OpenAI Codex prompt definitions
+- **🐙 GitHub Copilot**: `.github/prompts/` - Prompt collections for Copilot Chat
+- **🔧 Qwen Code**: `.qwen/commands/kiro/` - Qwen Code slash commands
+- **🌊 Windsurf IDE**: `.windsurf/workflows/` - Windsurf workflow definitions
 
 #### Common Configuration Files
 - **Configuration files**: Copy platform-specific config files (`CLAUDE.md`, `AGENTS.md`, etc.) as needed
@@ -54,17 +57,17 @@ When you run commands, the following directories will be automatically created:
 
 ```
 your-project/
-├── .claude/
-│   └── commands/          # Copied command definitions
+├── .claude/commands/kiro/     # Claude Code slash command definitions
+├── .codex/prompts/            # Codex CLI prompt definitions
+├── .cursor/commands/kiro/     # Cursor command definitions
+├── .gemini/commands/kiro/     # Gemini CLI TOML definitions
+├── .github/prompts/           # GitHub Copilot prompt collections
+├── .qwen/commands/kiro/       # Qwen Code slash command definitions
+├── .windsurf/workflows/       # Windsurf workflow files
 ├── .kiro/
-│   ├── steering/          # Auto-generated steering documents
-│   └── specs/             # Auto-generated feature specifications  
-├── CLAUDE.md              # Copied and renamed from a language-specific file (e.g., CLAUDE_en.md or CLAUDE_zh-TW.md)
-├── CLAUDE_en.md           # English version of Claude Code configuration
-├── CLAUDE_zh-TW.md        # Traditional Chinese version of Claude Code configuration
-├── README.md              # Japanese version README
-├── README_en.md           # English version README
-├── README_zh-TW.md        # Traditional Chinese version README
+│   ├── steering/              # Auto-generated steering documents
+│   └── specs/                 # Auto-generated feature specifications  
+├── CLAUDE.md                  # Copied and renamed from language-specific quickstart
 └── (your project files)
 ```
 

--- a/docs/README/README_ja.md
+++ b/docs/README/README_ja.md
@@ -20,7 +20,7 @@ Claude Code、Cursor、Gemini CLI、Codex CLIの4つのプラットフォーム�
 
 ## 概要
 
-このプロジェクトは、複数のAI開発プラットフォーム（Claude Code、Cursor、Gemini CLI、Codex CLI）に対応したSlash Commandsを活用して、仕様駆動開発（Spec-Driven Development）を効率的に行うためのツールセットを提供します。各開発フェーズで適切なコマンドを使用することで、プラットフォームを問わず体系的かつ品質の高い開発プロセスを実現できます。
+このプロジェクトは、複数のAI開発プラットフォーム（Claude Code、Cursor、Gemini CLI、Codex CLI、GitHub Copilot、Qwen Code、Windsurf）に対応したSlash Commandsを活用して、仕様駆動開発（Spec-Driven Development）を効率的に行うためのツールセットを提供します。各開発フェーズで適切なコマンドを使用することで、プラットフォームを問わず体系的かつ品質の高い開発プロセスを実現できます。
 
 ## セットアップ
 
@@ -30,9 +30,12 @@ Claude Code、Cursor、Gemini CLI、Codex CLIの4つのプラットフォーム�
 
 #### プラットフォーム別ディレクトリ
 - **🤖 Claude Code**: `.claude/commands/` - Claude Code用のSlash Commands定義
+- **🧠 Codex CLI**: `.codex/prompts/` - OpenAI Codex用のプロンプト定義
 - **🔮 Cursor**: `.cursor/commands/` - Cursor用のコマンド定義  
 - **⚡ Gemini CLI**: `.gemini/commands/` - Gemini CLI用のTOMLファイル
-- **🧠 Codex CLI**: `.codex/commands/` - OpenAI Codex用のプロンプト定義
+- **🐙 GitHub Copilot**: `.github/prompts/` - Copilot向けプロンプト定義
+- **🔧 Qwen Code**: `.qwen/commands/kiro/` - Qwen Code用コマンド定義
+- **🌊 Windsurf IDE**: `.windsurf/workflows/` - Windsurf用ワークフロー定義
 
 #### 共通設定ファイル
 - **設定ファイル**: プラットフォームに応じた設定ファイル（`CLAUDE.md`、`AGENTS.md`等）をコピー
@@ -58,10 +61,13 @@ Claude Code、Cursor、Gemini CLI、Codex CLIの4つのプラットフォーム�
 ```
 あなたのプロジェクト/
 ├── プラットフォーム別ディレクトリ（使用するものをコピー）
-│   ├── .claude/commands/      # Claude Code用コマンド定義
-│   ├── .cursor/commands/      # Cursor用コマンド定義
-│   ├── .gemini/commands/      # Gemini CLI用TOML設定
-│   └── .codex/commands/       # Codex CLI用プロンプト定義
+│   ├── .claude/commands/kiro/ # Claude Code用コマンド定義
+│   ├── .codex/prompts/       # Codex CLI用プロンプト定義
+│   ├── .cursor/commands/kiro/# Cursor用コマンド定義
+│   ├── .gemini/commands/kiro/# Gemini CLI用TOML設定
+│   ├── .github/prompts/      # GitHub Copilot用プロンプト定義
+│   ├── .qwen/commands/kiro/  # Qwen Code用コマンド定義
+│   └── .windsurf/workflows/  # Windsurf用ワークフロー定義
 ├── .kiro/
 │   ├── steering/              # 自動生成されるステアリング文書
 │   └── specs/                 # 自動生成される機能仕様

--- a/docs/README/README_zh-TW.md
+++ b/docs/README/README_zh-TW.md
@@ -17,7 +17,7 @@
 
 ## 專案簡介
 
-本專案提供一套跨多個 AI 平台（Claude Code、Cursor、Gemini CLI、Codex CLI）的規格驅動開發工具組，利用 Slash Commands 讓每個開發階段都能系統化、高品質地推進，不論您偏好哪個平台。
+本專案提供一套跨多個 AI 平台（Claude Code、Cursor、Gemini CLI、Codex CLI、GitHub Copilot、Qwen Code、Windsurf）的規格驅動開發工具組，利用 Slash Commands 讓每個開發階段都能系統化、高品質地推進，不論您偏好哪個平台。
 
 ## 安裝與設定
 
@@ -27,9 +27,12 @@
 
 #### 平台專用目錄
 - **🤖 Claude Code**：`.claude/commands/` - Slash Commands 定義
+- **🧠 Codex CLI**：`.codex/prompts/` - OpenAI Codex 提示定義
 - **🔮 Cursor**：`.cursor/commands/` - Cursor 指令定義  
 - **⚡ Gemini CLI**：`.gemini/commands/` - TOML 配置檔案
-- **🧠 Codex CLI**：`.codex/commands/` - OpenAI Codex 提示定義
+- **🐙 GitHub Copilot**：`.github/prompts/` - Copilot 提示集合
+- **🔧 Qwen Code**：`.qwen/commands/kiro/` - Qwen Code 指令定義
+- **🌊 Windsurf IDE**：`.windsurf/workflows/` - Windsurf 工作流程
 
 #### 通用配置檔案
 - **配置檔案**：根據平台複製相應的配置檔案（`CLAUDE.md`、`AGENTS.md` 等）
@@ -53,17 +56,17 @@
 
 ```
 your-project/
-├── .claude/
-│   └── commands/          # 指令定義
+├── .claude/commands/kiro/   # Claude Code 指令定義
+├── .codex/prompts/          # Codex CLI 提示定義
+├── .cursor/commands/kiro/   # Cursor 指令定義
+├── .gemini/commands/kiro/   # Gemini CLI 設定
+├── .github/prompts/         # GitHub Copilot 提示集合
+├── .qwen/commands/kiro/     # Qwen Code 指令定義
+├── .windsurf/workflows/     # Windsurf 工作流程
 ├── .kiro/
-│   ├── steering/          # 自動產生的 steering 文件
-│   └── specs/             # 自動產生的功能規格
-├── CLAUDE.md              # 由 CLAUDE_zh-TW.md 複製並改名（專案主要設定）
-├── CLAUDE_zh-TW.md        # 繁體中文版 Claude Code 設定
-├── CLAUDE_en.md           # 英文版 Claude Code 設定
-├── README.md              # 日文版 README
-├── README_en.md           # 英文版 README
-├── README_zh-TW.md        # 繁體中文版 README
+│   ├── steering/            # 自動產生的 steering 文件
+│   └── specs/               # 自動產生的功能規格
+├── CLAUDE.md                # 由語言別檔案複製並改名
 └── (你的專案檔案)
 ```
 

--- a/docs/RELEASE_NOTES/RELEASE_NOTES_en.md
+++ b/docs/RELEASE_NOTES/RELEASE_NOTES_en.md
@@ -4,6 +4,26 @@ New features and improvements for cc-sdd. See [CHANGELOG.md](../../CHANGELOG.md)
 
 ---
 
+## 🚀 Ver 2.0.0-alpha.3 (2025-10-22)
+
+### 🎯 Highlights
+- **Windsurf IDE support**: Added a dedicated manifest, workflow templates under `.windsurf/workflows/`, and an AGENTS.md quickstart so Windsurf users can run the full kiro Spec-Driven Development workflow with `npx cc-sdd@next --windsurf`.
+- **CLI experience refresh**: Updated completion guides and recommended models so the setup summary now points Windsurf users to the correct follow-up commands and manual QA flow.
+
+### 🧪 Quality & Tooling
+- Added `realManifestWindsurf` integration tests that cover dry-run planning, cross-platform (macOS/Linux) execution, and completion messaging.
+- Extended CLI argument parsing to recognize the `--windsurf` alias and ensured the agent registry emits the correct layout metadata.
+
+### 📚 Documentation
+- Refreshed the root README, CLI docs (`tools/cc-sdd/README*`), and legacy guides (`docs/README/README_{en,ja,zh-TW}.md`) with Windsurf instructions, updated quick-start matrices, and the manual QA checklist using `npx cc-sdd@next --windsurf`.
+
+### 📈 Key Metrics
+- **Supported platforms**: 7 (Claude Code, Cursor IDE, Gemini CLI, Codex CLI, GitHub Copilot, Qwen Code, Windsurf IDE)
+- **Command/workflow count**: 11 per agent (identical spec/validate/steering coverage)
+- **Automated coverage**: 1 new real-manifest test scenario dedicated to Windsurf
+
+---
+
 ## 🚀 Ver 2.0.0 (2025-10-13)
 
 ### 🎯 Highlights

--- a/docs/RELEASE_NOTES/RELEASE_NOTES_ja.md
+++ b/docs/RELEASE_NOTES/RELEASE_NOTES_ja.md
@@ -4,6 +4,24 @@ cc-sddの新機能・改善情報をお届けします。技術的な変更履�
 
 ---
 
+## 🚀 Ver 2.0.0-alpha.3 (2025-10-22)
+
+### 🎯 ハイライト
+- **Windsurf IDE 対応**： `.windsurf/workflows/` に 11 個のワークフローと AGENTS.md を展開するマニフェストを追加し、`npx cc-sdd@next --windsurf` で kiro 仕様駆動ワークフローを利用できるようになりました。
+- **CLI 体験刷新**： セットアップ完了メッセージに Windsurf 向け推奨モデルと次のコマンドを表示し、ドキュメントでは手動 QA フローを案内するように改善しました。
+
+### 🧪 品質 / ツール
+- macOS / Linux の dry-run・適用結果を検証する `realManifestWindsurf` 統合テストを追加。
+- CLI 引数パーサーに `--windsurf` フラグを追加し、エージェントレジストリへ Windsurf のレイアウト情報を登録。
+
+### 📚 ドキュメント
+- ルート README、`tools/cc-sdd/README*`、および `docs/README/README_{en,ja,zh-TW}.md` を更新し、Windsurf 導入手順と `npx cc-sdd@next --windsurf` を用いた手動 QA 手順を追記しました。
+
+### 📈 指標
+- **対応プラットフォーム**: 7（Claude Code, Cursor IDE, Gemini CLI, Codex CLI, GitHub Copilot, Qwen Code, Windsurf IDE）
+- **コマンド / ワークフロー数**: 各エージェント 11（spec / validate / steering 共通構成）
+- **自動テスト**: Windsurf 専用 real manifest テストを 1 本追加
+
 ## 🚀 Ver 2.0.0 (2025-10-13)
 
 ### 🎯 ハイライト

--- a/tools/cc-sdd/README.md
+++ b/tools/cc-sdd/README.md
@@ -1,6 +1,6 @@
 # cc-sdd: Customize spec-driven development for your team's workflow
 
-✨ **Transform Claude Code / Cursor IDE / Gemini CLI / Codex CLI / GitHub Copilot / Qwen Code from prototype to production-ready development, while customizing every spec and steering template so requirements, design docs, tasks, and project memory match your team workflow.**
+✨ **Transform Claude Code / Cursor IDE / Gemini CLI / Codex CLI / GitHub Copilot / Qwen Code / Windsurf from prototype to production-ready development, while customizing every spec and steering template so requirements, design docs, tasks, and project memory match your team workflow.**
 
 <!-- npm badges -->
 [![npm version](https://img.shields.io/npm/v/cc-sdd?logo=npm)](https://www.npmjs.com/package/cc-sdd?activeTab=readme)
@@ -11,7 +11,7 @@
 English | <a href="https://github.com/gotalab/cc-sdd/blob/main/tools/cc-sdd/README_ja.md">日本語</a> | <a href="https://github.com/gotalab/cc-sdd/blob/main/tools/cc-sdd/README_zh-TW.md">繁體中文</a>
 </sub></div>
 
-Brings **AI-DLC (AI Driven Development Lifecycle)** to Claude Code, Cursor IDE, Gemini CLI, Codex CLI, GitHub Copilot, and Qwen Code. **AI-native processes** with **minimal human approval gates**: AI drives execution while humans validate critical decisions at each phase.
+Brings **AI-DLC (AI Driven Development Lifecycle)** to Claude Code, Cursor IDE, Gemini CLI, Codex CLI, GitHub Copilot, Qwen Code, and Windsurf. **AI-native processes** with **minimal human approval gates**: AI drives execution while humans validate critical decisions at each phase.
 
 🎯 **Perfect for**: Escaping the 70% overhead trap of traditional development (meetings, documentation, ceremonies) to achieve **weeks-to-hours delivery** with AI-native execution and human quality gates.
 
@@ -25,7 +25,7 @@ Run one command to install **AI-DLC** (AI Driven Development Lifecycle) with **S
 # Basic installation (defaults: English docs, Claude Code)
 npx cc-sdd@latest
 
-# Alpha version with major updates (v2.0.0-alpha.2)
+# Alpha version with major updates (v2.0.0-alpha.3)
 npx cc-sdd@next
 
 # With language options (default: --lang en)
@@ -41,6 +41,7 @@ npx cc-sdd@latest --cursor --lang ja    # or @next for latest alpha
 npx cc-sdd@next --codex --lang ja       # Requires alpha version
 npx cc-sdd@next --copilot --lang ja     # Requires alpha version
 npx cc-sdd@latest --qwen --lang ja      # or @next for latest alpha
+npx cc-sdd@next --windsurf --lang ja    # Requires alpha version (Windsurf workflows)
 ```
 
 ## 🌐 Supported Languages
@@ -109,11 +110,12 @@ npx cc-sdd@latest --qwen --lang ja      # or @next for latest alpha
 |-------|--------|----------|--------|
 | **Claude Code** | ✅ Full | 11 slash commands | `CLAUDE.md` |
 | **Claude Code SubAgents** | ✅ Full | 12 commands + 9 subagents (requires cc-sdd@next) | `CLAUDE.md`, `.claude/agents/kiro/` |
-| **Gemini CLI** | ✅ Full | 11 commands | `GEMINI.md` |
 | **Cursor IDE** | ✅ Full | 11 commands | `AGENTS.md` |
+| **Gemini CLI** | ✅ Full | 11 commands | `GEMINI.md` |
 | **Codex CLI** | ✅ Full | 11 prompts | `AGENTS.md` |
 | **GitHub Copilot** | ✅ Full | 11 prompts | `AGENTS.md` |
 | **Qwen Code** | ✅ Full | 11 commands | `QWEN.md` |
+| **Windsurf IDE** | ✅ Full | 11 workflows | `.windsurf/workflows/`, `AGENTS.md` (requires cc-sdd@next) |
 | Others | 📅 Planned | - | - |
  
 ## 📋 Commands
@@ -174,6 +176,7 @@ project/
 ├── .claude/commands/kiro/    # 11 slash commands
 ├── .codex/prompts/           # 11 prompt commands (Codex CLI)
 ├── .github/prompts/          # 11 prompt commands (GitHub Copilot)
+├── .windsurf/workflows/      # 11 workflow files (Windsurf IDE)
 ├── .kiro/settings/           # Shared rules & templates (variables resolved with {{KIRO_DIR}})
 ├── .kiro/specs/              # Feature specifications
 ├── .kiro/steering/           # AI guidance rules

--- a/tools/cc-sdd/README_ja.md
+++ b/tools/cc-sdd/README_ja.md
@@ -1,6 +1,6 @@
 # cc-sdd: AIコーディングエージェントを本番仕様駆動にするワンコマンドセットアップ
 
-✨ **Claude Code / Cursor IDE / Gemini CLI / Codex CLI / GitHub Copilot / Qwen Codeをプロトタイプからプロダクション開発プロセスへ、さらに仕様・ステアリングテンプレートの出力をチームのワークフローに合わせてカスタマイズできます。**
+✨ **Claude Code / Cursor IDE / Gemini CLI / Codex CLI / GitHub Copilot / Qwen Code / Windsurfをプロトタイプからプロダクション開発プロセスへ、さらに仕様・ステアリングテンプレートの出力をチームのワークフローに合わせてカスタマイズできます。**
 
 <!-- npm badges -->
 [![npm version](https://img.shields.io/npm/v/cc-sdd?logo=npm)](https://www.npmjs.com/package/cc-sdd?activeTab=readme)
@@ -11,7 +11,7 @@
 <a href="https://github.com/gotalab/cc-sdd/blob/main/tools/cc-sdd/README.md">English</a> | 日本語 | <a href="https://github.com/gotalab/cc-sdd/blob/main/tools/cc-sdd/README_zh-TW.md">繁體中文</a>
 </sub></div>
 
-Claude Code、Cursor IDE、Gemini CLI、Codex CLI、GitHub Copilot、Qwen Codeを **AI-DLC (AI駆動開発ライフサイクル)**へ。**AIネイティブプロセス**と**最小限の人間承認ゲート**：AIが実行を駆動し、人間が各フェーズで重要な決定を検証。
+Claude Code、Cursor IDE、Gemini CLI、Codex CLI、GitHub Copilot、Qwen Code、Windsurfを **AI-DLC (AI駆動開発ライフサイクル)**へ。**AIネイティブプロセス**と**最小限の人間承認ゲート**：AIが実行を駆動し、人間が各フェーズで重要な決定を検証。
 
 🎯 **最適な用途**: 従来開発の70%オーバーヘッド（会議・文書・儀式）から脱却し、AIネイティブ実行と人間品質ゲートで **週単位から時間単位の納期** を実現。
 
@@ -25,7 +25,7 @@ Claude Code、Cursor IDE、Gemini CLI、Codex CLI、GitHub Copilot、Qwen Code�
 # 基本インストール（デフォルト: 英語、Claude Code）
 npx cc-sdd@latest
 
-# アルファ版（大幅アップデート版 v2.0.0-alpha.2）
+# アルファ版（大幅アップデート版 v2.0.0-alpha.3）
 npx cc-sdd@next
 
 # 言語オプション（デフォルト: --lang en）
@@ -41,6 +41,7 @@ npx cc-sdd@latest --cursor --lang ja    # または @next で最新アルファ�
 npx cc-sdd@next --codex --lang ja       # アルファ版必須
 npx cc-sdd@next --copilot --lang ja     # アルファ版必須
 npx cc-sdd@latest --qwen --lang ja      # または @next で最新アルファ版
+npx cc-sdd@next --windsurf --lang ja    # アルファ版必須（Windsurf向けワークフロー）
 ```
 
 ## 🌐 対応言語
@@ -109,11 +110,12 @@ npx cc-sdd@latest --qwen --lang ja      # または @next で最新アルファ�
 |-------|--------|----------|--------|
 | **Claude Code** | ✅ 完全対応 | 11スラッシュコマンド | `CLAUDE.md` |
 | **Claude Code SubAgents** | ✅ 完全対応 | 12コマンド + 9サブエージェント（cc-sdd@nextが必要） | `CLAUDE.md`, `.claude/agents/kiro/` |
-| **Gemini CLI** | ✅ 完全対応 | 11コマンド | `GEMINI.md` |
 | **Cursor IDE** | ✅ 完全対応 | 11コマンド | `AGENTS.md` |
+| **Gemini CLI** | ✅ 完全対応 | 11コマンド | `GEMINI.md` |
 | **Codex CLI** | ✅ 完全対応 | 11プロンプト | `AGENTS.md` |
 | **GitHub Copilot** | ✅ 完全対応 | 11プロンプト | `AGENTS.md` |
 | **Qwen Code** | ✅ 完全対応 | 11コマンド | `QWEN.md` |
+| **Windsurf IDE** | ✅ 完全対応 | 11ワークフロー | `.windsurf/workflows/`, `AGENTS.md`（cc-sdd@nextが必要） |
 | その他 | 📅 予定 | - | - |
  
 ## 📋 コマンド
@@ -174,6 +176,7 @@ project/
 ├── .claude/commands/kiro/    # 11のスラッシュコマンド
 ├── .codex/prompts/           # 11のプロンプトコマンド（Codex CLI）
 ├── .github/prompts/          # 11のプロンプトコマンド（GitHub Copilot）
+├── .windsurf/workflows/      # 11のワークフローファイル（Windsurf IDE）
 ├── .kiro/settings/           # 共通ルールとテンプレート（{{KIRO_DIR}} を展開）
 ├── .kiro/specs/             # 機能仕様書
 ├── .kiro/steering/          # AI指導ルール

--- a/tools/cc-sdd/README_zh-TW.md
+++ b/tools/cc-sdd/README_zh-TW.md
@@ -1,6 +1,6 @@
 # cc-sdd: 一鍵讓 AI 程式代理進入生產級規格開發
 
-✨ **將 Claude Code / Cursor IDE / Gemini CLI / Codex CLI / GitHub Copilot / Qwen Code 從原型開發轉型為生產級開發，同時可將規格與指導模板調整為符合團隊流程。**
+✨ **將 Claude Code / Cursor IDE / Gemini CLI / Codex CLI / GitHub Copilot / Qwen Code / Windsurf 從原型開發轉型為生產級開發，同時可將規格與指導模板調整為符合團隊流程。**
 
 <!-- npm badges -->
 [![npm version](https://img.shields.io/npm/v/cc-sdd?logo=npm)](https://www.npmjs.com/package/cc-sdd?activeTab=readme)
@@ -11,7 +11,7 @@
 <a href="https://github.com/gotalab/cc-sdd/blob/main/tools/cc-sdd/README.md">English</a> | <a href="https://github.com/gotalab/cc-sdd/blob/main/tools/cc-sdd/README_ja.md">日本語</a> | 繁體中文
 </sub></div>
 
-將 **AI-DLC (AI 驅動開發生命週期)** 帶入 Claude Code、Cursor IDE、Gemini CLI、Codex CLI、GitHub Copilot 與 Qwen Code。**AI 原生流程**與**最小限的人類批准關卡**：AI 驅動執行，人類在各階段驗證關鍵決策。
+將 **AI-DLC (AI 驅動開發生命週期)** 帶入 Claude Code、Cursor IDE、Gemini CLI、Codex CLI、GitHub Copilot、Qwen Code 與 Windsurf。**AI 原生流程**與**最小限的人類批准關卡**：AI 驅動執行，人類在各階段驗證關鍵決策。
 
 🎯 **最佳用途**：脱離傳統開發 70% 的額外負擔（會議、文件、儀式），透過 AI 原生執行和人類品質關卡實現 **從週到小時的交付**。
 
@@ -25,7 +25,7 @@
 # 基本安裝（預設：英文文件，Claude Code 代理）
 npx cc-sdd@latest
 
-# Alpha 版本（重大更新版 v2.0.0-alpha.2）
+# Alpha 版本（重大更新版 v2.0.0-alpha.3）
 npx cc-sdd@next
 
 # 語言選項（預設：--lang en）
@@ -41,6 +41,7 @@ npx cc-sdd@latest --cursor --lang zh-TW    # 或 @next 取得最新 alpha
 npx cc-sdd@next --codex --lang zh-TW       # 需要 alpha 版本
 npx cc-sdd@next --copilot --lang zh-TW     # 需要 alpha 版本
 npx cc-sdd@latest --qwen --lang zh-TW      # 或 @next 取得最新 alpha
+npx cc-sdd@next --windsurf --lang zh-TW    # 需要 alpha 版本（Windsurf 工作流程）
 ```
 
 ## 🌐 支援語言
@@ -109,11 +110,12 @@ npx cc-sdd@latest --qwen --lang zh-TW      # 或 @next 取得最新 alpha
 |------|------|------|------|
 | **Claude Code** | ✅ 完全支援 | 11 個斜線指令 | `CLAUDE.md` |
 | **Claude Code SubAgents** | ✅ 完全支援 | 12 個指令 + 9 個子代理（需 cc-sdd@next） | `CLAUDE.md`, `.claude/agents/kiro/` |
-| **Gemini CLI** | ✅ 完全支援 | 11 個指令 | `GEMINI.md` |
 | **Cursor IDE** | ✅ 完全支援 | 11 個指令 | `AGENTS.md` |
+| **Gemini CLI** | ✅ 完全支援 | 11 個指令 | `GEMINI.md` |
 | **Codex CLI** | ✅ 完全支援 | 11 個提示 | `AGENTS.md` |
 | **GitHub Copilot** | ✅ 完全支援 | 11 個提示 | `AGENTS.md` |
 | **Qwen Code** | ✅ 完全支援 | 11 個指令 | `QWEN.md` |
+| **Windsurf IDE** | ✅ 完全支援 | 11 個工作流程 | `.windsurf/workflows/`, `AGENTS.md`（需 cc-sdd@next） |
 | 其他 | 📅 規劃中 | - | - |
 
 ## 📋 指令
@@ -174,6 +176,7 @@ project/
 ├── .claude/commands/kiro/    # 11 個斜線指令
 ├── .codex/prompts/           # 11 個提示指令（Codex CLI）
 ├── .github/prompts/          # 11 個提示指令（GitHub Copilot）
+├── .windsurf/workflows/      # 11 個工作流程檔案（Windsurf IDE）
 ├── .kiro/settings/           # 共用規則與模板（以 {{KIRO_DIR}} 展開）
 ├── .kiro/specs/             # 功能規格文件
 ├── .kiro/steering/          # AI 指導規則

--- a/tools/cc-sdd/package.json
+++ b/tools/cc-sdd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-sdd",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Transform your coding workflow with AI-DLC and Spec-Driven Development. One command installs 11 powerful slash commands, Project Memory, and structured development workflows for Claude Code.",
   "keywords": ["claude-code", "spec-driven-development", "kiro", "steering", "ai-development", "tdd", "ai-dlc", "ai-driven-development-life-cycle"],
   "author": "Gota",

--- a/tools/cc-sdd/src/agents/registry.ts
+++ b/tools/cc-sdd/src/agents/registry.ts
@@ -153,6 +153,24 @@ export const agentDefinitions = {
     },
     manifestId: 'gemini-cli',
   },
+  windsurf: {
+    label: 'Windsurf IDE',
+    description:
+      'Installs kiro workflows in `.windsurf/workflows/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
+    aliasFlags: ['--windsurf'],
+    recommendedModels: ['Claude 4.5 Sonnet or newer', 'GPT-5-Codex'],
+    layout: {
+      commandsDir: '.windsurf/workflows',
+      agentDir: '.windsurf',
+      docFile: 'AGENTS.md',
+    },
+    commands: {
+      spec: '`/kiro-spec-init <what-to-build>`',
+      steering: '`/kiro-steering`',
+      steeringCustom: '`/kiro-steering-custom <what-to-create-custom-steering-document>`',
+    },
+    manifestId: 'windsurf',
+  },
   'qwen-code': {
     label: 'Qwen Code',
     description:

--- a/tools/cc-sdd/templates/agents/windsurf/commands/kiro-spec-design.md
+++ b/tools/cc-sdd/templates/agents/windsurf/commands/kiro-spec-design.md
@@ -1,0 +1,166 @@
+---
+description: Create comprehensive technical design for a specification
+auto_execution_mode: 3
+---
+<meta>
+description: Create comprehensive technical design for a specification
+argument-hint: <feature-name:$1> [-y:$2]
+</meta>
+
+# Technical Design Generator
+
+<background_information>
+- **Mission**: Generate comprehensive technical design document that translates requirements (WHAT) into architectural design (HOW)
+- **Success Criteria**:
+  - All requirements mapped to technical components with clear interfaces
+  - Appropriate architecture discovery and research completed
+  - Design aligns with steering context and existing patterns
+  - Visual diagrams included for complex architectures
+</background_information>
+
+<instructions>
+## Core Task
+Generate technical design document for feature **$1** based on approved requirements.
+
+## Execution Steps
+
+### Step 1: Load Context
+
+**Read all necessary context**:
+- `{{KIRO_DIR}}/specs/$1/spec.json`, `requirements.md`, `design.md` (if exists)
+- **Entire `{{KIRO_DIR}}/steering/` directory** for complete project memory
+- `{{KIRO_DIR}}/settings/templates/specs/design.md` for document structure
+- `{{KIRO_DIR}}/settings/rules/design-principles.md` for design principles
+
+**Validate requirements approval**:
+- If `-y` flag provided ($2 == "-y"): Auto-approve requirements in spec.json
+- Otherwise: Verify approval status (stop if unapproved, see Safety & Fallback)
+
+### Step 2: Discovery & Analysis
+
+**Critical: This phase ensures design is based on complete, accurate information.**
+
+1. **Classify Feature Type**:
+   - **New Feature** (greenfield) → Full discovery required
+   - **Extension** (existing system) → Integration-focused discovery
+   - **Simple Addition** (CRUD/UI) → Minimal or no discovery
+   - **Complex Integration** → Comprehensive analysis required
+
+2. **Execute Appropriate Discovery Process**:
+   
+   **For Complex/New Features**:
+   - Read and execute `{{KIRO_DIR}}/settings/rules/design-discovery-full.md`
+   - Conduct thorough research using WebSearch/WebFetch:
+     - Latest architectural patterns and best practices
+     - External dependency verification (APIs, libraries, versions, compatibility)
+     - Official documentation, migration guides, known issues
+     - Performance benchmarks and security considerations
+   
+   **For Extensions**:
+   - Read and execute `{{KIRO_DIR}}/settings/rules/design-discovery-light.md`
+   - Focus on integration points, existing patterns, compatibility
+   - Use Grep to analyze existing codebase patterns
+   
+   **For Simple Additions**:
+   - Skip formal discovery, quick pattern check only
+
+3. **Retain Discovery Findings for Step 3**:
+   - External API contracts and constraints
+   - Technology decisions with rationale
+   - Existing patterns to follow or extend
+   - Integration points and dependencies
+   - Identified risks and mitigation strategies
+
+### Step 3: Generate Design Document
+
+1. **Load Design Template and Rules**:
+   - Read `{{KIRO_DIR}}/settings/templates/specs/design.md` for structure
+   - Read `{{KIRO_DIR}}/settings/rules/design-principles.md` for principles
+
+2. **Generate Design Document**:
+   - **Follow specs/design.md template structure and generation instructions strictly**
+   - **Integrate all discovery findings**: Use researched information (APIs, patterns, technologies) throughout component definitions, architecture decisions, and integration points
+   - If existing design.md found in Step 1, use it as reference context (merge mode)
+   - Apply design rules: Type Safety, Visual Communication, Formal Tone
+   - Use language specified in spec.json
+
+3. **Update Metadata** in spec.json:
+   - Set `phase: "design-generated"`
+   - Set `approvals.design.generated: true, approved: false`
+   - Set `approvals.requirements.approved: true`
+   - Update `updated_at` timestamp
+
+## Critical Constraints
+ - **Type Safety**:
+   - Enforce strong typing aligned with the project's technology stack.
+   - For statically typed languages, define explicit types/interfaces and avoid unsafe casts.
+   - For TypeScript, never use `any`; prefer precise types and generics.
+   - For dynamically typed languages, provide type hints/annotations where available (e.g., Python type hints) and validate inputs at boundaries.
+   - Document public interfaces and contracts clearly to ensure cross-component type safety.
+- **Latest Information**: Use WebSearch/WebFetch for external dependencies and best practices
+- **Steering Alignment**: Respect existing architecture patterns from steering context
+- **Template Adherence**: Follow specs/design.md template structure and generation instructions strictly
+- **Design Focus**: Architecture and interfaces ONLY, no implementation code
+</instructions>
+
+## Tool Guidance
+- **Read first**: Load all context before taking action (specs, steering, templates, rules)
+- **Research when uncertain**: Use WebSearch/WebFetch for external dependencies, APIs, and latest best practices
+- **Analyze existing code**: Use Grep to find patterns and integration points in codebase
+- **Write last**: Generate design.md only after all research and analysis complete
+
+## Output Description
+
+**Command execution output** (separate from design.md content):
+
+Provide brief summary in the language specified in spec.json:
+
+1. **Status**: Confirm design document generated at `{{KIRO_DIR}}/specs/$1/design.md`
+2. **Discovery Type**: Which discovery process was executed (full/light/minimal)
+3. **Key Findings**: 2-3 critical insights from discovery that shaped the design
+4. **Next Action**: Approval workflow guidance (see Safety & Fallback)
+
+**Format**: Concise Markdown (under 200 words) - this is the command output, NOT the design document itself
+
+**Note**: The actual design document follows `{{KIRO_DIR}}/settings/templates/specs/design.md` structure.
+
+## Safety & Fallback
+
+### Error Scenarios
+
+**Requirements Not Approved**:
+- **Stop Execution**: Cannot proceed without approved requirements
+- **User Message**: "Requirements not yet approved. Approval required before design generation."
+- **Suggested Action**: "Run `/kiro-spec-design $1 -y` to auto-approve requirements and proceed"
+
+**Missing Requirements**:
+- **Stop Execution**: Requirements document must exist
+- **User Message**: "No requirements.md found at `{{KIRO_DIR}}/specs/$1/requirements.md`"
+- **Suggested Action**: "Run `/kiro-spec-requirements $1` to generate requirements first"
+
+**Template Missing**:
+- **User Message**: "Template file missing at `{{KIRO_DIR}}/settings/templates/specs/design.md`"
+- **Suggested Action**: "Check repository setup or restore template file"
+- **Fallback**: Use inline basic structure with warning
+
+**Steering Context Missing**:
+- **Warning**: "Steering directory empty or missing - design may not align with project standards"
+- **Proceed**: Continue with generation but note limitation in output
+
+**Discovery Complexity Unclear**:
+- **Default**: Use full discovery process (`{{KIRO_DIR}}/settings/rules/design-discovery-full.md`)
+- **Rationale**: Better to over-research than miss critical context
+
+### Next Phase: Task Generation
+
+**If Design Approved**:
+- Review generated design at `{{KIRO_DIR}}/specs/$1/design.md`
+- **Optional**: Run `/kiro-validate-design $1` for interactive quality review
+- Then `/kiro-spec-tasks $1 -y` to generate implementation tasks
+
+**If Modifications Needed**:
+- Provide feedback and re-run `/kiro-spec-design $1`
+- Existing design used as reference (merge mode)
+
+**Note**: Design approval is mandatory before proceeding to task generation.
+

--- a/tools/cc-sdd/templates/agents/windsurf/commands/kiro-spec-impl.md
+++ b/tools/cc-sdd/templates/agents/windsurf/commands/kiro-spec-impl.md
@@ -1,0 +1,113 @@
+---
+description: Execute spec tasks using TDD methodology
+auto_execution_mode: 3
+---
+<meta>
+description: Execute spec tasks using TDD methodology
+argument-hint: <feature-name:$1> [task-numbers:$2]
+</meta>
+
+# Implementation Task Executor
+
+<background_information>
+- **Mission**: Execute implementation tasks using Test-Driven Development methodology based on approved specifications
+- **Success Criteria**:
+  - All tests written before implementation code
+  - Code passes all tests with no regressions
+  - Tasks marked as completed in tasks.md
+  - Implementation aligns with design and requirements
+</background_information>
+
+<instructions>
+## Core Task
+Execute implementation tasks for feature **$1** using Test-Driven Development.
+
+## Execution Steps
+
+### Step 1: Load Context
+
+**Read all necessary context**:
+- `{{KIRO_DIR}}/specs/$1/spec.json`, `requirements.md`, `design.md`, `tasks.md`
+- **Entire `{{KIRO_DIR}}/steering/` directory** for complete project memory
+
+**Validate approvals**:
+- Verify tasks are approved in spec.json (stop if not, see Safety & Fallback)
+
+### Step 2: Select Tasks
+
+**Determine which tasks to execute**:
+- If `$2` provided: Execute specified task numbers (e.g., "1.1" or "1,2,3")
+- Otherwise: Execute all pending tasks (unchecked `- [ ]` in tasks.md)
+
+### Step 3: Execute with TDD
+
+For each selected task, follow Kent Beck's TDD cycle:
+
+1. **RED - Write Failing Test**:
+   - Write test for the next small piece of functionality
+   - Test should fail (code doesn't exist yet)
+   - Use descriptive test names
+
+2. **GREEN - Write Minimal Code**:
+   - Implement simplest solution to make test pass
+   - Focus only on making THIS test pass
+   - Avoid over-engineering
+
+3. **REFACTOR - Clean Up**:
+   - Improve code structure and readability
+   - Remove duplication
+   - Apply design patterns where appropriate
+   - Ensure all tests still pass after refactoring
+
+4. **VERIFY - Validate Quality**:
+   - All tests pass (new and existing)
+   - No regressions in existing functionality
+   - Code coverage maintained or improved
+
+5. **MARK COMPLETE**:
+   - Update checkbox from `- [ ]` to `- [x]` in tasks.md
+
+## Critical Constraints
+- **TDD Mandatory**: Tests MUST be written before implementation code
+- **Task Scope**: Implement only what the specific task requires
+- **Test Coverage**: All new code must have tests
+- **No Regressions**: Existing tests must continue to pass
+- **Design Alignment**: Implementation must follow design.md specifications
+</instructions>
+
+## Tool Guidance
+- **Read first**: Load all context before implementation
+- **Test first**: Write tests before code
+- Use **WebSearch/WebFetch** for library documentation when needed
+
+## Output Description
+
+Provide brief summary in the language specified in spec.json:
+
+1. **Tasks Executed**: Task numbers and test results
+2. **Status**: Completed tasks marked in tasks.md, remaining tasks count
+
+**Format**: Concise (under 150 words)
+
+## Safety & Fallback
+
+### Error Scenarios
+
+**Tasks Not Approved or Missing Spec Files**:
+- **Stop Execution**: All spec files must exist and tasks must be approved
+- **Suggested Action**: "Complete previous phases: `/kiro-spec-requirements`, `/kiro-spec-design`, `/kiro-spec-tasks`"
+
+**Test Failures**:
+- **Stop Implementation**: Fix failing tests before continuing
+- **Action**: Debug and fix, then re-run
+
+### Task Execution
+
+**Execute specific task(s)**:
+- `/kiro-spec-impl $1 1.1` - Single task
+- `/kiro-spec-impl $1 1,2,3` - Multiple tasks
+
+**Execute all pending**:
+- `/kiro-spec-impl $1` - All unchecked tasks
+
+

--- a/tools/cc-sdd/templates/agents/windsurf/commands/kiro-spec-init.md
+++ b/tools/cc-sdd/templates/agents/windsurf/commands/kiro-spec-init.md
@@ -1,0 +1,69 @@
+---
+description: Initialize a new specification with detailed project description
+auto_execution_mode: 3
+---
+<meta>
+description: Initialize a new specification with detailed project description
+argument-hint: <project-description>
+</meta>
+
+# Spec Initialization
+
+<background_information>
+- **Mission**: Initialize the first phase of spec-driven development by creating directory structure and metadata for a new specification
+- **Success Criteria**:
+  - Generate appropriate feature name from project description
+  - Create unique spec structure without conflicts
+  - Provide clear path to next phase (requirements generation)
+</background_information>
+
+<instructions>
+## Core Task
+Generate a unique feature name from the project description ($ARGUMENTS) and initialize the specification structure.
+
+## Execution Steps
+1. **Check Uniqueness**: Verify `{{KIRO_DIR}}/specs/` for naming conflicts (append number suffix if needed)
+2. **Create Directory**: `{{KIRO_DIR}}/specs/[feature-name]/`
+3. **Initialize Files Using Templates**:
+   - Read `{{KIRO_DIR}}/settings/templates/specs/init.json`
+   - Read `{{KIRO_DIR}}/settings/templates/specs/requirements-init.md`
+   - Replace placeholders:
+     - `{{FEATURE_NAME}}` → generated feature name
+     - `{{TIMESTAMP}}` → current ISO 8601 timestamp
+     - `{{PROJECT_DESCRIPTION}}` → $ARGUMENTS
+   - Write `spec.json` and `requirements.md` to spec directory
+
+## Important Constraints
+- DO NOT generate requirements/design/tasks at this stage
+- Follow stage-by-stage development principles
+- Maintain strict phase separation
+- Only initialization is performed in this phase
+</instructions>
+
+## Tool Guidance
+- Use **Glob** to check existing spec directories for name uniqueness
+- Use **Read** to fetch templates: `init.json` and `requirements-init.md`
+- Use **Write** to create spec.json and requirements.md after placeholder replacement
+- Perform validation before any file write operation
+
+## Output Description
+Provide output in the language specified in `spec.json` with the following structure:
+
+1. **Generated Feature Name**: `feature-name` format with 1-2 sentence rationale
+2. **Project Summary**: Brief summary (1 sentence)
+3. **Created Files**: Bullet list with full paths
+4. **Next Step**: Command block showing `/kiro-spec-requirements <feature-name>`
+5. **Notes**: Explain why only initialization was performed (2-3 sentences on phase separation)
+
+**Format Requirements**:
+- Use Markdown headings (##, ###)
+- Wrap commands in code blocks
+- Keep total output concise (under 250 words)
+- Use clear, professional language per `spec.json.language`
+
+## Safety & Fallback
+- **Ambiguous Feature Name**: If feature name generation is unclear, propose 2-3 options and ask user to select
+- **Template Missing**: If template files don't exist in `{{KIRO_DIR}}/settings/templates/specs/`, report error with specific missing file path and suggest checking repository setup
+- **Directory Conflict**: If feature name already exists, append numeric suffix (e.g., `feature-name-2`) and notify user of automatic conflict resolution
+- **Write Failure**: Report error with specific path and suggest checking permissions or disk space
+

--- a/tools/cc-sdd/templates/agents/windsurf/commands/kiro-spec-requirements.md
+++ b/tools/cc-sdd/templates/agents/windsurf/commands/kiro-spec-requirements.md
@@ -1,0 +1,99 @@
+---
+description: Generate comprehensive requirements for a specification
+auto_execution_mode: 3
+---
+<meta>
+description: Generate comprehensive requirements for a specification
+argument-hint: <feature-name:$1>
+</meta>
+
+# Requirements Generation
+
+<background_information>
+- **Mission**: Generate comprehensive, testable requirements in EARS format based on the project description from spec initialization
+- **Success Criteria**:
+  - Create complete requirements document aligned with steering context
+  - Use proper EARS syntax for all acceptance criteria
+  - Focus on core functionality without implementation details
+  - Update metadata to track generation status
+</background_information>
+
+<instructions>
+## Core Task
+Generate complete requirements for feature **$1** based on the project description in requirements.md.
+
+## Execution Steps
+
+1. **Load Context**:
+   - Read `{{KIRO_DIR}}/specs/$1/spec.json` for language and metadata
+   - Read `{{KIRO_DIR}}/specs/$1/requirements.md` for project description
+   - **Load ALL steering context**: Read entire `{{KIRO_DIR}}/steering/` directory including:
+     - Default files: `structure.md`, `tech.md`, `product.md`
+     - All custom steering files (regardless of mode settings)
+     - This provides complete project memory and context
+
+2. **Read Guidelines**:
+   - Read `{{KIRO_DIR}}/settings/rules/ears-format.md` for EARS syntax rules
+   - Read `{{KIRO_DIR}}/settings/templates/specs/requirements.md` for document structure
+
+3. **Generate Requirements**:
+   - Create initial requirements based on project description
+   - Group related functionality into logical requirement areas
+   - Apply EARS format to all acceptance criteria
+   - Use language specified in spec.json
+
+4. **Update Metadata**:
+   - Set `phase: "requirements-generated"`
+   - Set `approvals.requirements.generated: true`
+   - Update `updated_at` timestamp
+
+## Important Constraints
+- Focus on WHAT, not HOW (no implementation details)
+- All acceptance criteria MUST use proper EARS syntax
+- Requirements must be testable and verifiable
+- Choose appropriate subject for EARS statements (system/service name for software)
+- Generate initial version first, then iterate with user feedback (no sequential questions upfront)
+</instructions>
+
+## Tool Guidance
+- **Read first**: Load all context (spec, steering, rules, templates) before generation
+- **Write last**: Update requirements.md only after complete generation
+- Use **WebSearch/WebFetch** only if external domain knowledge needed
+
+## Output Description
+Provide output in the language specified in spec.json with:
+
+1. **Generated Requirements Summary**: Brief overview of major requirement areas (3-5 bullets)
+2. **Document Status**: Confirm requirements.md updated and spec.json metadata updated
+3. **Next Steps**: Guide user on how to proceed (approve and continue, or modify)
+
+**Format Requirements**:
+- Use Markdown headings for clarity
+- Include file paths in code blocks
+- Keep summary concise (under 300 words)
+
+## Safety & Fallback
+
+### Error Scenarios
+- **Missing Project Description**: If requirements.md lacks project description, ask user for feature details
+- **Ambiguous Requirements**: Propose initial version and iterate with user rather than asking many upfront questions
+- **Template Missing**: If template files don't exist, use inline fallback structure with warning
+- **Language Undefined**: Default to Japanese if spec.json doesn't specify language
+- **Incomplete Requirements**: After generation, explicitly ask user if requirements cover all expected functionality
+- **Steering Directory Empty**: Warn user that project context is missing and may affect requirement quality
+
+### Next Phase: Design Generation
+
+**If Requirements Approved**:
+- Review generated requirements at `{{KIRO_DIR}}/specs/$1/requirements.md`
+- **Optional Gap Analysis** (for existing codebases):
+  - Run `/kiro-validate-gap $1` to analyze implementation gap with current code
+  - Identifies existing components, integration points, and implementation strategy
+  - Recommended for brownfield projects; skip for greenfield
+- Then `/kiro-spec-design $1 -y` to proceed to design phase
+
+**If Modifications Needed**:
+- Provide feedback and re-run `/kiro-spec-requirements $1`
+
+**Note**: Approval is mandatory before proceeding to design phase.
+

--- a/tools/cc-sdd/templates/agents/windsurf/commands/kiro-spec-status.md
+++ b/tools/cc-sdd/templates/agents/windsurf/commands/kiro-spec-status.md
@@ -1,0 +1,89 @@
+---
+description: Show specification status and progress
+auto_execution_mode: 3
+---
+<meta>
+description: Show specification status and progress
+argument-hint: <feature-name:$1>
+</meta>
+
+# Specification Status
+
+<background_information>
+- **Mission**: Display comprehensive status and progress for a specification
+- **Success Criteria**:
+  - Show current phase and completion status
+  - Identify next actions and blockers
+  - Provide clear visibility into progress
+</background_information>
+
+<instructions>
+## Core Task
+Generate status report for feature **$1** showing progress across all phases.
+
+## Execution Steps
+
+### Step 1: Load Spec Context
+- Read `{{KIRO_DIR}}/specs/$1/spec.json` for metadata and phase status
+- Read existing files: `requirements.md`, `design.md`, `tasks.md` (if they exist)
+- Check `{{KIRO_DIR}}/specs/$1/` directory for available files
+
+### Step 2: Analyze Status
+
+**Parse each phase**:
+- **Requirements**: Count requirements and acceptance criteria
+- **Design**: Check for architecture, components, diagrams
+- **Tasks**: Count completed vs total tasks (parse `- [x]` vs `- [ ]`)
+- **Approvals**: Check approval status in spec.json
+
+### Step 3: Generate Report
+
+Create report in the language specified in spec.json covering:
+1. **Current Phase & Progress**: Where the spec is in the workflow
+2. **Completion Status**: Percentage complete for each phase
+3. **Task Breakdown**: If tasks exist, show completed/remaining counts
+4. **Next Actions**: What needs to be done next
+5. **Blockers**: Any issues preventing progress
+
+## Critical Constraints
+- Use language from spec.json
+- Calculate accurate completion percentages
+- Identify specific next action commands
+</instructions>
+
+## Tool Guidance
+- **Read**: Load spec.json first, then other spec files as needed
+- **Parse carefully**: Extract completion data from tasks.md checkboxes
+- Use **Glob** to check which spec files exist
+
+## Output Description
+
+Provide status report in the language specified in spec.json:
+
+**Report Structure**:
+1. **Feature Overview**: Name, phase, last updated
+2. **Phase Status**: Requirements, Design, Tasks with completion %
+3. **Task Progress**: If tasks exist, show X/Y completed
+4. **Next Action**: Specific command to run next
+5. **Issues**: Any blockers or missing elements
+
+**Format**: Clear, scannable format with emojis (✅/⏳/❌) for status
+
+## Safety & Fallback
+
+### Error Scenarios
+
+**Spec Not Found**:
+- **Message**: "No spec found for `$1`. Check available specs in `{{KIRO_DIR}}/specs/`"
+- **Action**: List available spec directories
+
+**Incomplete Spec**:
+- **Warning**: Identify which files are missing
+- **Suggested Action**: Point to next phase command
+
+### List All Specs
+
+To see all available specs:
+- Run with no argument or use wildcard
+- Shows all specs in `{{KIRO_DIR}}/specs/` with their status
+

--- a/tools/cc-sdd/templates/agents/windsurf/commands/kiro-spec-tasks.md
+++ b/tools/cc-sdd/templates/agents/windsurf/commands/kiro-spec-tasks.md
@@ -1,0 +1,133 @@
+---
+description: Generate implementation tasks for a specification
+auto_execution_mode: 3
+---
+<meta>
+description: Generate implementation tasks for a specification
+argument-hint: <feature-name:$1> [-y:$2]
+</meta>
+
+# Implementation Tasks Generator
+
+<background_information>
+- **Mission**: Generate detailed, actionable implementation tasks that translate technical design into executable work items
+- **Success Criteria**:
+  - All requirements mapped to specific tasks
+  - Tasks properly sized (1-3 hours each)
+  - Clear task progression with proper hierarchy
+  - Natural language descriptions focused on capabilities
+</background_information>
+
+<instructions>
+## Core Task
+Generate implementation tasks for feature **$1** based on approved requirements and design.
+
+## Execution Steps
+
+### Step 1: Load Context
+
+**Read all necessary context**:
+- `{{KIRO_DIR}}/specs/$1/spec.json`, `requirements.md`, `design.md`
+- `{{KIRO_DIR}}/specs/$1/tasks.md` (if exists, for merge mode)
+- **Entire `{{KIRO_DIR}}/steering/` directory** for complete project memory
+
+**Validate approvals**:
+- If `-y` flag provided ($2 == "-y"): Auto-approve requirements and design in spec.json
+- Otherwise: Verify both approved (stop if not, see Safety & Fallback)
+
+### Step 2: Generate Implementation Tasks
+
+**Load generation rules and template**:
+- Read `{{KIRO_DIR}}/settings/rules/tasks-generation.md` for principles
+- Read `{{KIRO_DIR}}/settings/templates/specs/tasks.md` for format
+
+**Generate task list following all rules**:
+- Use language specified in spec.json
+- Map all requirements to tasks
+- Ensure all design components included
+- Verify task progression is logical and incremental
+- If existing tasks.md found, merge with new content
+
+### Step 3: Finalize
+
+**Write and update**:
+- Create/update `{{KIRO_DIR}}/specs/$1/tasks.md`
+- Update spec.json metadata:
+  - Set `phase: "tasks-generated"`
+  - Set `approvals.tasks.generated: true, approved: false`
+  - Set `approvals.requirements.approved: true`
+  - Set `approvals.design.approved: true`
+  - Update `updated_at` timestamp
+
+## Critical Constraints
+- **Follow rules strictly**: All principles in tasks-generation.md are mandatory
+- **Natural Language**: Describe what to do, not code structure details
+- **Complete Coverage**: ALL requirements must map to tasks
+- **Maximum 2 Levels**: Major tasks and sub-tasks only (no deeper nesting)
+- **Sequential Numbering**: Major tasks increment (1, 2, 3...), never repeat
+- **Task Integration**: Every task must connect to the system (no orphaned work)
+</instructions>
+
+## Tool Guidance
+- **Read first**: Load all context, rules, and templates before generation
+- **Write last**: Generate tasks.md only after complete analysis and verification
+
+## Output Description
+
+Provide brief summary in the language specified in spec.json:
+
+1. **Status**: Confirm tasks generated at `{{KIRO_DIR}}/specs/$1/tasks.md`
+2. **Task Summary**: 
+   - Total: X major tasks, Y sub-tasks
+   - All Z requirements covered
+   - Average task size: 1-3 hours per sub-task
+3. **Quality Validation**:
+   - ✅ All requirements mapped to tasks
+   - ✅ Task dependencies verified
+   - ✅ Testing tasks included
+4. **Next Action**: Review tasks and proceed when ready
+
+**Format**: Concise (under 200 words)
+
+## Safety & Fallback
+
+### Error Scenarios
+
+**Requirements or Design Not Approved**:
+- **Stop Execution**: Cannot proceed without approved requirements and design
+- **User Message**: "Requirements and design must be approved before task generation"
+- **Suggested Action**: "Run `/kiro-spec-tasks $1 -y` to auto-approve both and proceed"
+
+**Missing Requirements or Design**:
+- **Stop Execution**: Both documents must exist
+- **User Message**: "Missing requirements.md or design.md at `{{KIRO_DIR}}/specs/$1/`"
+- **Suggested Action**: "Complete requirements and design phases first"
+
+**Incomplete Requirements Coverage**:
+- **Warning**: "Not all requirements mapped to tasks. Review coverage."
+- **User Action Required**: Confirm intentional gaps or regenerate tasks
+
+**Template/Rules Missing**:
+- **User Message**: "Template or rules files missing in `{{KIRO_DIR}}/settings/`"
+- **Fallback**: Use inline basic structure with warning
+- **Suggested Action**: "Check repository setup or restore template files"
+
+### Next Phase: Implementation
+
+**Before Starting Implementation**:
+- **IMPORTANT**: Clear conversation history and free up context before running `/kiro-spec-impl`
+- This applies when starting first task OR switching between tasks
+- Fresh context ensures clean state and proper task focus
+
+**If Tasks Approved**:
+- Execute specific task: `/kiro-spec-impl $1 1.1` (recommended: clear context between each task)
+- Execute multiple tasks: `/kiro-spec-impl $1 1.1,1.2` (use cautiously, clear context between tasks)
+- Without arguments: `/kiro-spec-impl $1` (executes all pending tasks - NOT recommended due to context bloat)
+
+**If Modifications Needed**:
+- Provide feedback and re-run `/kiro-spec-tasks $1`
+- Existing tasks used as reference (merge mode)
+
+**Note**: The implementation phase will guide you through executing tasks with appropriate context and validation.
+
+

--- a/tools/cc-sdd/templates/agents/windsurf/commands/kiro-steering-custom.md
+++ b/tools/cc-sdd/templates/agents/windsurf/commands/kiro-steering-custom.md
@@ -1,0 +1,129 @@
+---
+description: Create custom steering documents for specialized project contexts
+auto_execution_mode: 3
+---
+<meta>
+description: Create custom steering documents for specialized project contexts
+</meta>
+
+# Kiro Custom Steering Creation
+
+<background_information>
+**Role**: Create specialized steering documents beyond core files (product, tech, structure).
+
+**Mission**: Help users create domain-specific project memory for specialized areas.
+
+**Success Criteria**:
+- Custom steering captures specialized patterns
+- Follows same granularity principles as core steering
+- Provides clear value for specific domain
+</background_information>
+
+<instructions>
+## Workflow
+
+1. **Ask user** for custom steering needs:
+   - Domain/topic (e.g., "API standards", "testing approach")
+   - Specific requirements or patterns to document
+
+2. **Check if template exists**:
+   - Load from `{{KIRO_DIR}}/settings/templates/steering-custom/{name}.md` if available
+   - Use as starting point, customize based on project
+
+3. **Analyze codebase** (JIT) for relevant patterns:
+   - **Glob** for related files
+   - **Read** for existing implementations
+   - **Grep** for specific patterns
+
+4. **Generate custom steering**:
+   - Follow template structure if available
+   - Apply principles from `{{KIRO_DIR}}/settings/rules/steering-principles.md`
+   - Focus on patterns, not exhaustive lists
+   - Keep to 100-200 lines (2-3 minute read)
+
+5. **Create file** in `{{KIRO_DIR}}/steering/{name}.md`
+
+## Available Templates
+
+Templates available in `{{KIRO_DIR}}/settings/templates/steering-custom/`:
+
+1. **api-standards.md** - REST/GraphQL conventions, error handling
+2. **testing.md** - Test organization, mocking, coverage
+3. **security.md** - Auth patterns, input validation, secrets
+4. **database.md** - Schema design, migrations, query patterns
+5. **error-handling.md** - Error types, logging, retry strategies
+6. **authentication.md** - Auth flows, permissions, session management
+7. **deployment.md** - CI/CD, environments, rollback procedures
+
+Load template when needed, customize for project.
+
+## Steering Principles
+
+From `{{KIRO_DIR}}/settings/rules/steering-principles.md`:
+
+- **Patterns over lists**: Document patterns, not every file/component
+- **Single domain**: One topic per file
+- **Concrete examples**: Show patterns with code
+- **Maintainable size**: 100-200 lines typical
+- **Security first**: Never include secrets or sensitive data
+
+</instructions>
+
+## Tool guidance
+
+- **Read**: Load template, analyze existing code
+- **Glob**: Find related files for pattern analysis
+- **Grep**: Search for specific patterns
+- **LS**: Understand relevant structure
+
+**JIT Strategy**: Load template only when creating that type of steering.
+
+## Output description
+
+Chat summary with file location (file created directly).
+
+```
+✅ Custom Steering Created
+
+## Created:
+- {{KIRO_DIR}}/steering/api-standards.md
+
+## Based On:
+- Template: api-standards.md
+- Analyzed: src/api/ directory patterns
+- Extracted: REST conventions, error format
+
+## Content:
+- Endpoint naming patterns
+- Request/response format
+- Error handling conventions
+- Authentication approach
+
+Review and customize as needed.
+```
+
+## Examples
+
+### Success: API Standards
+**Input**: "Create API standards steering"  
+**Action**: Load template, analyze src/api/, extract patterns  
+**Output**: api-standards.md with project-specific REST conventions
+
+### Success: Testing Strategy
+**Input**: "Document our testing approach"  
+**Action**: Load template, analyze test files, extract patterns  
+**Output**: testing.md with test organization and mocking strategies
+
+## Safety & Fallback
+
+- **No template**: Generate from scratch based on domain knowledge
+- **Security**: Never include secrets (load principles)
+- **Validation**: Ensure doesn't duplicate core steering content
+
+## Notes
+
+- Templates are starting points, customize for project
+- Follow same granularity principles as core steering
+- All steering files loaded as project memory
+- Custom files equally important as core files
+

--- a/tools/cc-sdd/templates/agents/windsurf/commands/kiro-steering.md
+++ b/tools/cc-sdd/templates/agents/windsurf/commands/kiro-steering.md
@@ -1,0 +1,145 @@
+---
+description: Manage {{KIRO_DIR}}/steering/ as persistent project knowledge
+auto_execution_mode: 3
+---
+<meta>
+description: Manage {{KIRO_DIR}}/steering/ as persistent project knowledge
+</meta>
+
+# Kiro Steering Management
+
+<background_information>
+**Role**: Maintain `{{KIRO_DIR}}/steering/` as persistent project memory.
+
+**Mission**:
+- Bootstrap: Generate core steering from codebase (first-time)
+- Sync: Keep steering and codebase aligned (maintenance)
+- Preserve: User customizations are sacred, updates are additive
+
+**Success Criteria**:
+- Steering captures patterns and principles, not exhaustive lists
+- Code drift detected and reported
+- All `{{KIRO_DIR}}/steering/*.md` treated equally (core + custom)
+</background_information>
+
+<instructions>
+## Scenario Detection
+
+Check `{{KIRO_DIR}}/steering/` status:
+
+**Bootstrap Mode**: Empty OR missing core files (product.md, tech.md, structure.md)  
+**Sync Mode**: All core files exist
+
+---
+
+## Bootstrap Flow
+
+1. Load templates from `{{KIRO_DIR}}/settings/templates/steering/`
+2. Analyze codebase (JIT):
+   - `glob_file_search` for source files
+   - `read_file` for README, package.json, etc.
+   - `grep` for patterns
+3. Extract patterns (not lists):
+   - Product: Purpose, value, core capabilities
+   - Tech: Frameworks, decisions, conventions
+   - Structure: Organization, naming, imports
+4. Generate steering files (follow templates)
+5. Load principles from `{{KIRO_DIR}}/settings/rules/steering-principles.md`
+6. Present summary for review
+
+**Focus**: Patterns that guide decisions, not catalogs of files/dependencies.
+
+---
+
+## Sync Flow
+
+1. Load all existing steering (`{{KIRO_DIR}}/steering/*.md`)
+2. Analyze codebase for changes (JIT)
+3. Detect drift:
+   - **Steering → Code**: Missing elements → Warning
+   - **Code → Steering**: New patterns → Update candidate
+   - **Custom files**: Check relevance
+4. Propose updates (additive, preserve user content)
+5. Report: Updates, warnings, recommendations
+
+**Update Philosophy**: Add, don't replace. Preserve user sections.
+
+---
+
+## Granularity Principle
+
+From `{{KIRO_DIR}}/settings/rules/steering-principles.md`:
+
+> "If new code follows existing patterns, steering shouldn't need updating."
+
+Document patterns and principles, not exhaustive lists.
+
+**Bad**: List every file in directory tree  
+**Good**: Describe organization pattern with examples
+
+</instructions>
+
+## Tool guidance
+
+- `glob_file_search`: Find source/config files
+- `read_file`: Read steering, docs, configs
+- `grep`: Search patterns
+- `list_dir`: Analyze structure
+
+**JIT Strategy**: Fetch when needed, not upfront.
+
+## Output description
+
+Chat summary only (files updated directly).
+
+### Bootstrap:
+```
+✅ Steering Created
+
+## Generated:
+- product.md: [Brief description]
+- tech.md: [Key stack]
+- structure.md: [Organization]
+
+Review and approve as Source of Truth.
+```
+
+### Sync:
+```
+✅ Steering Updated
+
+## Changes:
+- tech.md: React 18 → 19
+- structure.md: Added API pattern
+
+## Code Drift:
+- Components not following import conventions
+
+## Recommendations:
+- Consider api-standards.md
+```
+
+## Examples
+
+### Bootstrap
+**Input**: Empty steering, React TypeScript project  
+**Output**: 3 files with patterns - "Feature-first", "TypeScript strict", "React 19"
+
+### Sync
+**Input**: Existing steering, new `/api` directory  
+**Output**: Updated structure.md, flagged non-compliant files, suggested api-standards.md
+
+## Safety & Fallback
+
+- **Security**: Never include keys, passwords, secrets (see principles)
+- **Uncertainty**: Report both states, ask user
+- **Preservation**: Add rather than replace when in doubt
+
+## Notes
+
+- All `{{KIRO_DIR}}/steering/*.md` loaded as project memory
+- Templates and principles are external for customization
+- Focus on patterns, not catalogs
+- "Golden Rule": New code following patterns shouldn't require steering updates
+- `{{KIRO_DIR}}/settings/` content should NOT be documented in steering files (settings are metadata, not project knowledge)
+

--- a/tools/cc-sdd/templates/agents/windsurf/commands/kiro-validate-design.md
+++ b/tools/cc-sdd/templates/agents/windsurf/commands/kiro-validate-design.md
@@ -1,0 +1,96 @@
+---
+description: Interactive technical design quality review and validation
+auto_execution_mode: 3
+---
+<meta>
+description: Interactive technical design quality review and validation
+argument-hint: <feature-name:$1>
+</meta>
+
+# Technical Design Validation
+
+<background_information>
+- **Mission**: Conduct interactive quality review of technical design to ensure readiness for implementation
+- **Success Criteria**:
+  - Critical issues identified (maximum 3 most important concerns)
+  - Balanced assessment with strengths recognized
+  - Clear GO/NO-GO decision with rationale
+  - Actionable feedback for improvements if needed
+</background_information>
+
+<instructions>
+## Core Task
+Interactive design quality review for feature **$1** based on approved requirements and design document.
+
+## Execution Steps
+
+1. **Load Context**:
+   - Read `{{KIRO_DIR}}/specs/$1/spec.json` for language and metadata
+   - Read `{{KIRO_DIR}}/specs/$1/requirements.md` for requirements
+   - Read `{{KIRO_DIR}}/specs/$1/design.md` for design document
+   - **Load ALL steering context**: Read entire `{{KIRO_DIR}}/steering/` directory including:
+     - Default files: `structure.md`, `tech.md`, `product.md`
+     - All custom steering files (regardless of mode settings)
+     - This provides complete project memory and context
+
+2. **Read Review Guidelines**:
+   - Read `{{KIRO_DIR}}/settings/rules/design-review.md` for review criteria and process
+
+3. **Execute Design Review**:
+   - Follow design-review.md process: Analysis → Critical Issues → Strengths → GO/NO-GO
+   - Limit to 3 most important concerns
+   - Engage interactively with user
+   - Use language specified in spec.json for output
+
+4. **Provide Decision and Next Steps**:
+   - Clear GO/NO-GO decision with rationale
+   - Guide user on proceeding based on decision
+
+## Important Constraints
+- **Quality assurance, not perfection seeking**: Accept acceptable risk
+- **Critical focus only**: Maximum 3 issues, only those significantly impacting success
+- **Interactive approach**: Engage in dialogue, not one-way evaluation
+- **Balanced assessment**: Recognize both strengths and weaknesses
+- **Actionable feedback**: All suggestions must be implementable
+</instructions>
+
+## Tool Guidance
+- **Read first**: Load all context (spec, steering, rules) before review
+- **Grep if needed**: Search codebase for pattern validation or integration checks
+- **Interactive**: Engage with user throughout the review process
+
+## Output Description
+Provide output in the language specified in spec.json with:
+
+1. **Review Summary**: Brief overview (2-3 sentences) of design quality and readiness
+2. **Critical Issues**: Maximum 3, following design-review.md format
+3. **Design Strengths**: 1-2 positive aspects
+4. **Final Assessment**: GO/NO-GO decision with rationale and next steps
+
+**Format Requirements**:
+- Use Markdown headings for clarity
+- Follow design-review.md output format
+- Keep summary concise
+
+## Safety & Fallback
+
+### Error Scenarios
+- **Missing Design**: If design.md doesn't exist, stop with message: "Run `/kiro-spec-design $1` first to generate design document"
+- **Design Not Generated**: If design phase not marked as generated in spec.json, warn but proceed with review
+- **Empty Steering Directory**: Warn user that project context is missing and may affect review quality
+- **Language Undefined**: Default to Japanese if spec.json doesn't specify language
+
+### Next Phase: Task Generation
+
+**If Design Passes Validation (GO Decision)**:
+- Review feedback and apply changes if needed
+- Run `/kiro-spec-tasks $1` to generate implementation tasks
+- Or `/kiro-spec-tasks $1 -y` to auto-approve and proceed directly
+
+**If Design Needs Revision (NO-GO Decision)**:
+- Address critical issues identified
+- Re-run `/kiro-spec-design $1` with improvements
+- Re-validate with `/kiro-validate-design $1`
+
+**Note**: Design validation is recommended but optional. Quality review helps catch issues early.
+

--- a/tools/cc-sdd/templates/agents/windsurf/commands/kiro-validate-gap.md
+++ b/tools/cc-sdd/templates/agents/windsurf/commands/kiro-validate-gap.md
@@ -1,0 +1,92 @@
+---
+description: Analyze implementation gap between requirements and existing codebase
+auto_execution_mode: 3
+---
+<meta>
+description: Analyze implementation gap between requirements and existing codebase
+argument-hint: <feature-name:$1>
+</meta>
+
+# Implementation Gap Validation
+
+<background_information>
+- **Mission**: Analyze the gap between requirements and existing codebase to inform implementation strategy
+- **Success Criteria**:
+  - Comprehensive understanding of existing codebase patterns and components
+  - Clear identification of missing capabilities and integration challenges
+  - Multiple viable implementation approaches evaluated
+  - Technical research needs identified for design phase
+</background_information>
+
+<instructions>
+## Core Task
+Analyze implementation gap for feature **$1** based on approved requirements and existing codebase.
+
+## Execution Steps
+
+1. **Load Context**:
+   - Read `{{KIRO_DIR}}/specs/$1/spec.json` for language and metadata
+   - Read `{{KIRO_DIR}}/specs/$1/requirements.md` for requirements
+   - **Load ALL steering context**: Read entire `{{KIRO_DIR}}/steering/` directory including:
+     - Default files: `structure.md`, `tech.md`, `product.md`
+     - All custom steering files (regardless of mode settings)
+     - This provides complete project memory and context
+
+2. **Read Analysis Guidelines**:
+   - Read `{{KIRO_DIR}}/settings/rules/gap-analysis.md` for comprehensive analysis framework
+
+3. **Execute Gap Analysis**:
+   - Follow gap-analysis.md framework for thorough investigation
+   - Analyze existing codebase using Grep and Read tools
+   - Use WebSearch/WebFetch for external dependency research if needed
+   - Evaluate multiple implementation approaches (extend/new/hybrid)
+   - Use language specified in spec.json for output
+
+4. **Generate Analysis Document**:
+   - Create comprehensive gap analysis following the output guidelines in gap-analysis.md
+   - Present multiple viable options with trade-offs
+   - Flag areas requiring further research
+
+## Important Constraints
+- **Information over Decisions**: Provide analysis and options, not final implementation choices
+- **Multiple Options**: Present viable alternatives when applicable
+- **Thorough Investigation**: Use tools to deeply understand existing codebase
+- **Explicit Gaps**: Clearly flag areas needing research or investigation
+</instructions>
+
+## Tool Guidance
+- **Read first**: Load all context (spec, steering, rules) before analysis
+- **Grep extensively**: Search codebase for patterns, conventions, and integration points
+- **WebSearch/WebFetch**: Research external dependencies and best practices when needed
+- **Write last**: Generate analysis only after complete investigation
+
+## Output Description
+Provide output in the language specified in spec.json with:
+
+1. **Analysis Summary**: Brief overview (3-5 bullets) of scope, challenges, and recommendations
+2. **Document Status**: Confirm analysis approach used
+3. **Next Steps**: Guide user on proceeding to design phase
+
+**Format Requirements**:
+- Use Markdown headings for clarity
+- Keep summary concise (under 300 words)
+- Detailed analysis follows gap-analysis.md output guidelines
+
+## Safety & Fallback
+
+### Error Scenarios
+- **Missing Requirements**: If requirements.md doesn't exist, stop with message: "Run `/kiro-spec-requirements $1` first to generate requirements"
+- **Requirements Not Approved**: If requirements not approved, warn user but proceed (gap analysis can inform requirement revisions)
+- **Empty Steering Directory**: Warn user that project context is missing and may affect analysis quality
+- **Complex Integration Unclear**: Flag for comprehensive research in design phase rather than blocking
+- **Language Undefined**: Default to Japanese if spec.json doesn't specify language
+
+### Next Phase: Design Generation
+
+**If Gap Analysis Complete**:
+- Review gap analysis insights
+- Run `/kiro-spec-design $1` to create technical design document
+- Or `/kiro-spec-design $1 -y` to auto-approve requirements and proceed directly
+
+**Note**: Gap analysis is optional but recommended for brownfield projects to inform design decisions.
+

--- a/tools/cc-sdd/templates/agents/windsurf/commands/kiro-validate-impl.md
+++ b/tools/cc-sdd/templates/agents/windsurf/commands/kiro-validate-impl.md
@@ -1,0 +1,142 @@
+---
+description: Validate implementation against requirements, design, and tasks
+auto_execution_mode: 3
+---
+<meta>
+description: Validate implementation against requirements, design, and tasks
+argument-hint: [feature-name:$1] [task-numbers:$2]
+</meta>
+
+# Implementation Validation
+
+<background_information>
+- **Mission**: Verify that implementation aligns with approved requirements, design, and tasks
+- **Success Criteria**:
+  - All specified tasks marked as completed
+  - Tests exist and pass for implemented functionality
+  - Requirements traceability confirmed (EARS requirements covered)
+  - Design structure reflected in implementation
+  - No regressions in existing functionality
+</background_information>
+
+<instructions>
+## Core Task
+Validate implementation for feature(s) and task(s) based on approved specifications.
+
+## Execution Steps
+
+### 1. Detect Validation Target
+
+**If no arguments provided** (`$1` empty):
+- Parse conversation history for `/kiro-spec-impl <feature> [tasks]` commands
+- Extract feature names and task numbers from each execution
+- Aggregate all implemented tasks by feature
+- Report detected implementations (e.g., "user-auth: 1.1, 1.2, 1.3")
+- If no history found, scan `{{KIRO_DIR}}/specs/` for features with completed tasks `[x]`
+
+**If feature provided** (`$1` present, `$2` empty):
+- Use specified feature
+- Detect all completed tasks `[x]` in `{{KIRO_DIR}}/specs/$1/tasks.md`
+
+**If both feature and tasks provided** (`$1` and `$2` present):
+- Validate specified feature and tasks only (e.g., `user-auth 1.1,1.2`)
+
+### 2. Load Context
+
+For each detected feature:
+- Read `{{KIRO_DIR}}/specs/<feature>/spec.json` for metadata
+- Read `{{KIRO_DIR}}/specs/<feature>/requirements.md` for requirements
+- Read `{{KIRO_DIR}}/specs/<feature>/design.md` for design structure
+- Read `{{KIRO_DIR}}/specs/<feature>/tasks.md` for task list
+- **Load ALL steering context**: Read entire `{{KIRO_DIR}}/steering/` directory including:
+  - Default files: `structure.md`, `tech.md`, `product.md`
+  - All custom steering files (regardless of mode settings)
+
+### 3. Execute Validation
+
+For each task, verify:
+
+#### Task Completion Check
+- Checkbox is `[x]` in tasks.md
+- If not completed, flag as "Task not marked complete"
+
+#### Test Coverage Check
+- Tests exist for task-related functionality
+- Tests pass (no failures or errors)
+- Use Bash to run test commands (e.g., `npm test`, `pytest`)
+- If tests fail or don't exist, flag as "Test coverage issue"
+
+#### Requirements Traceability
+- Identify EARS requirements related to the task
+- Use Grep to search implementation for evidence of requirement coverage
+- If requirement not traceable to code, flag as "Requirement not implemented"
+
+#### Design Alignment
+- Check if design.md structure is reflected in implementation
+- Verify key interfaces, components, and modules exist
+- Use Grep/LS to confirm file structure matches design
+- If misalignment found, flag as "Design deviation"
+
+#### Regression Check
+- Run full test suite (if available)
+- Verify no existing tests are broken
+- If regressions detected, flag as "Regression detected"
+
+### 4. Generate Report
+
+Provide summary in the language specified in spec.json:
+- Validation summary by feature
+- Coverage report (tasks, requirements, design)
+- Issues and deviations with severity (Critical/Warning)
+- GO/NO-GO decision
+
+## Important Constraints
+- **Conversation-aware**: Prioritize conversation history for auto-detection
+- **Non-blocking warnings**: Design deviations are warnings unless critical
+- **Test-first focus**: Test coverage is mandatory for GO decision
+- **Traceability required**: All requirements must be traceable to implementation
+</instructions>
+
+## Tool Guidance
+- **Conversation parsing**: Extract `/kiro-spec-impl` patterns from history
+- **Read context**: Load all specs and steering before validation
+- **Bash for tests**: Execute test commands to verify pass status
+- **Grep for traceability**: Search codebase for requirement evidence
+- **LS/Glob for structure**: Verify file structure matches design
+
+## Output Description
+
+Provide output in the language specified in spec.json with:
+
+1. **Detected Target**: Features and tasks being validated (if auto-detected)
+2. **Validation Summary**: Brief overview per feature (pass/fail counts)
+3. **Issues**: List of validation failures with severity and location
+4. **Coverage Report**: Requirements/design/task coverage percentages
+5. **Decision**: GO (ready for next phase) / NO-GO (needs fixes)
+
+**Format Requirements**:
+- Use Markdown headings and tables for clarity
+- Flag critical issues with ⚠️ or 🔴
+- Keep summary concise (under 400 words)
+
+## Safety & Fallback
+
+### Error Scenarios
+- **No Implementation Found**: If no `/kiro-spec-impl` in history and no `[x]` tasks, report "No implementations detected"
+- **Test Command Unknown**: If test framework unclear, warn and skip test validation (manual verification required)
+- **Missing Spec Files**: If spec.json/requirements.md/design.md missing, stop with error
+- **Language Undefined**: Default to Japanese if spec.json doesn't specify language
+
+### Next Steps Guidance
+
+**If GO Decision**:
+- Implementation validated and ready
+- Proceed to deployment or next feature
+
+**If NO-GO Decision**:
+- Address critical issues listed
+- Re-run `/kiro-spec-impl <feature> [tasks]` for fixes
+- Re-validate with `/kiro-validate-impl [feature] [tasks]`
+
+**Note**: Validation is recommended after implementation to ensure spec alignment and quality.
+

--- a/tools/cc-sdd/templates/agents/windsurf/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/windsurf/docs/AGENTS.md
@@ -1,0 +1,44 @@
+# AI-DLC and Spec-Driven Development
+
+Kiro-style Spec Driven Development implementation on AI-DLC (AI Development Life Cycle)
+
+## Project Context
+
+### Paths
+- Steering: `{{KIRO_DIR}}/steering/`
+- Specs: `{{KIRO_DIR}}/specs/`
+
+### Steering vs Specification
+
+**Steering** (`{{KIRO_DIR}}/steering/`) - Guide AI with project-wide rules and context
+**Specs** (`{{KIRO_DIR}}/specs/`) - Formalize development process for individual features
+
+### Active Specifications
+- Check `{{KIRO_DIR}}/specs/` for active specifications
+- Use `/kiro-spec-status [feature-name]` to check progress
+
+## Development Guidelines
+{{DEV_GUIDELINES}}
+
+## Minimal Workflow
+- Phase 0 (optional): `/kiro-steering`, `/kiro-steering-custom`
+- Phase 1 (Specification):
+  - `/kiro-spec-init "description"`
+  - `/kiro-spec-requirements {feature}`
+  - `/kiro-validate-gap {feature}` (optional: for existing codebase)
+  - `/kiro-spec-design {feature} [-y]`
+  - `/kiro-validate-design {feature}` (optional: design review)
+  - `/kiro-spec-tasks {feature} [-y]`
+- Phase 2 (Implementation): `/kiro-spec-impl {feature} [tasks]`
+  - `/kiro-validate-impl {feature}` (optional: after implementation)
+- Progress check: `/kiro-spec-status {feature}` (use anytime)
+
+## Development Rules
+- 3-phase approval workflow: Requirements → Design → Tasks → Implementation
+- Human review required each phase; use `-y` only for intentional fast-track
+- Keep steering current and verify alignment with `/kiro-spec-status`
+
+## Steering Configuration
+- Load entire `{{KIRO_DIR}}/steering/` as project memory
+- Default files: `product.md`, `tech.md`, `structure.md`
+- Custom files are supported (managed via `/kiro-steering-custom`)

--- a/tools/cc-sdd/templates/manifests/windsurf.json
+++ b/tools/cc-sdd/templates/manifests/windsurf.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "artifacts": [
+    {
+      "id": "commands",
+      "source": {
+        "type": "templateDir",
+        "fromDir": "templates/agents/{{AGENT}}/commands",
+        "toDir": "{{AGENT_COMMANDS_DIR}}"
+      },
+      "when": { "agent": "windsurf" }
+    },
+    {
+      "id": "doc_main",
+      "source": {
+        "type": "templateFile",
+        "from": "templates/agents/{{AGENT}}/docs/AGENTS.md",
+        "toDir": ".",
+        "rename": "{{AGENT_DOC}}"
+      },
+      "when": { "agent": "windsurf" }
+    },
+    {
+      "id": "settings_common",
+      "source": {
+        "type": "templateDir",
+        "fromDir": "templates/shared/settings",
+        "toDir": "{{KIRO_DIR}}/settings"
+      },
+      "when": { "agent": "windsurf" }
+    }
+  ]
+}

--- a/tools/cc-sdd/test/args.test.ts
+++ b/tools/cc-sdd/test/args.test.ts
@@ -43,6 +43,7 @@ describe('parseArgs', () => {
     expect(parseArgs(['--claude-code']).agent).toBe('claude-code');
     expect(parseArgs(['--claude-agent']).agent).toBe('claude-code-agent');
     expect(parseArgs(['--claude-code-agent']).agent).toBe('claude-code-agent');
+    expect(parseArgs(['--windsurf']).agent).toBe('windsurf');
 
     expect(() => parseArgs(['--agent', 'qwen-code', '--gemini-cli'])).toThrowError(/agent.*conflict/i);
     expect(() => parseArgs(['--gemini-cli', '--qwen-code'])).toThrowError(/agent.*conflict/i);

--- a/tools/cc-sdd/test/realManifestWindsurf.test.ts
+++ b/tools/cc-sdd/test/realManifestWindsurf.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { runCli } from '../src/index';
+import { join } from 'node:path';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+const runtime = { platform: 'darwin' } as const;
+
+const makeIO = () => {
+  const logs: string[] = [];
+  const errs: string[] = [];
+  return {
+    io: {
+      log: (m: string) => logs.push(m),
+      error: (m: string) => errs.push(m),
+      exit: (_c: number) => {},
+    },
+    get logs() {
+      return logs;
+    },
+    get errs() {
+      return errs;
+    },
+  };
+};
+
+describe('real windsurf manifest', () => {
+  it('dry-run prints plan for windsurf.json with placeholders applied (mac)', async () => {
+    const repoRoot = join(process.cwd(), '..', '..');
+    const manifestPath = join(repoRoot, 'tools/cc-sdd/templates/manifests/windsurf.json');
+    const ctx = makeIO();
+    const code = await runCli(['--dry-run', '--lang', 'en', '--agent', 'windsurf', '--manifest', manifestPath], runtime, ctx.io, {});
+    expect(code).toBe(0);
+    const out = ctx.logs.join('\n');
+    expect(out).toMatch(/Plan \(dry-run\)/);
+    expect(out).toContain('[templateDir] commands: templates/agents/windsurf/commands -> .windsurf/workflows');
+    expect(out).toContain('[templateFile] doc_main: templates/agents/windsurf/docs/AGENTS.md -> ./AGENTS.md');
+    expect(out).toContain('[templateDir] settings_common: templates/shared/settings -> .kiro/settings');
+  });
+
+  it('dry-run prints plan including commands for linux via mac template', async () => {
+    const repoRoot = join(process.cwd(), '..', '..');
+    const manifestPath = join(repoRoot, 'tools/cc-sdd/templates/manifests/windsurf.json');
+    const ctx = makeIO();
+    const runtimeLinux = { platform: 'linux' } as const;
+    const code = await runCli(['--dry-run', '--lang', 'en', '--agent', 'windsurf', '--manifest', manifestPath], runtimeLinux, ctx.io, {});
+    expect(code).toBe(0);
+    const out = ctx.logs.join('\n');
+    expect(out).toMatch(/Plan \(dry-run\)/);
+    expect(out).toContain('[templateDir] commands: templates/agents/windsurf/commands -> .windsurf/workflows');
+    expect(out).toContain('[templateFile] doc_main: templates/agents/windsurf/docs/AGENTS.md -> ./AGENTS.md');
+    expect(out).toContain('[templateDir] settings_common: templates/shared/settings -> .kiro/settings');
+  });
+
+  it('shows windsurf recommendation message after applying plan', async () => {
+    const repoRoot = join(process.cwd(), '..', '..');
+    const manifestPath = join(repoRoot, 'tools/cc-sdd/templates/manifests/windsurf.json');
+    const ctx = makeIO();
+
+    const tmpDir = await mkdtemp(join(tmpdir(), 'ccsdd-windsurf-test-'));
+    const templatesRoot = join(repoRoot, 'tools/cc-sdd');
+
+    const code = await runCli(['--lang', 'en', '--agent', 'windsurf', '--manifest', manifestPath, '--yes'], runtime, ctx.io, {}, { cwd: tmpDir, templatesRoot });
+
+    expect(code).toBe(0);
+    const out = ctx.logs.join('\n');
+
+    expect(out).toMatch(/Setup completed: written=\d+, skipped=\d+/);
+    expect(out).toContain('Recommended models');
+    expect(out).toContain('Claude 4.5 Sonnet');
+    expect(out).toContain('GPT-5-Codex');
+    expect(out).toContain('Launch Windsurf IDE and run `/kiro-spec-init <what-to-build>` to create a new specification.');
+    expect(out).toMatch(
+      /Tip: Steering holds persistent project knowledge—patterns, standards, and org-wide policies\. Kick off `\/kiro-steering` \(essential for existing projects\) and\s+`\/kiro-steering-custom <what-to-create-custom-steering-document>`\. Maintain Regularly/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Windsurf templates, manifest, and registry wiring so cc-sdd can install workflows
- update docs/release notes for 2.0.0-alpha.3 and document manual QA flow with npx cc-sdd@next --windsurf
- extend tests and version metadata to cover the new agent

## Testing
- pnpm test realManifestWindsurf
