### PR TITLE
Automate GitHub Issue Lifecycle Management

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -42,7 +42,7 @@ jobs:
           stale-pr-label: 'stale'
 
           # 除外するラベル（これらのラベルが付いているissueはstaleにしない）
-          exempt-issue-labels: 'pinned,security,help wanted'
+          exempt-issue-labels: 'pinned,security,help-wanted'
 
           # PR も同様に処理するか（falseにすると issue のみ処理）
           # PR を処理したくない場合は以下を有効化


### PR DESCRIPTION
This pull request introduces a new workflow configuration to automatically manage stale issues and pull requests in the repository. The workflow uses the `actions/stale` GitHub Action to label inactive issues and PRs as "stale" and close them after a set period of inactivity. This helps keep the issue tracker organized and reduces maintenance overhead.

Automation of stale issue and PR management:

* Added `.github/workflows/stale.yml` to schedule daily checks for inactivity and automatically label and close stale issues and pull requests. The workflow includes customizable messages for labeling and closing, exemption for specific labels, and support for manual triggering.