### PR TITLE
chore: Bump version to 2.0.1

### DIFF
--- a/tools/cc-sdd/package.json
+++ b/tools/cc-sdd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-sdd",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Transform your coding workflow with AI-DLC and Spec-Driven Development. One command installs 11 powerful slash commands, Project Memory, and structured development workflows for 7 AI coding agents.",
   "keywords": ["claude-code", "cursor", "windsurf", "gemini-cli", "codex", "github-copilot", "qwen-code", "sdd", "spec-driven-development", "kiro", "steering", "ai-development", "tdd", "ai-dlc", "agentic-sdlc", "subagents", "parallel-tasks"],
   "author": "Gota",


### PR DESCRIPTION
## Summary

Bumps package version from 2.0.0 to 2.0.1 following the README improvements merged in #93.

### Changes

- Update `tools/cc-sdd/package.json` version: `2.0.0` → `2.0.1`

### Context

This patch version includes documentation improvements:
- Updated ghost icon (👻) to align with Kiro IDE branding
- Improved v2.0.0 highlights clarity for first-time npm package viewers
- Enhanced visual consistency across all language versions

### Release Notes

This is a documentation-only release with no functional changes to the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)