### PR TITLE
docs: fix confusing --kiro-dir example to avoid nested specs/specs/ structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ npx cc-sdd@latest --lang es        # Spanish
 npx cc-sdd@latest --dry-run
 
 # Custom specs directory
-npx cc-sdd@latest --kiro-dir docs/specs
+npx cc-sdd@latest --kiro-dir docs
 ```
 
 ---

--- a/tools/cc-sdd/README.md
+++ b/tools/cc-sdd/README.md
@@ -193,7 +193,7 @@ npx cc-sdd@latest --lang ja --os mac   # Optional explicit override (legacy flag
 npx cc-sdd@latest --dry-run --backup
 
 # Custom directory
-npx cc-sdd@latest --kiro-dir docs/specs
+npx cc-sdd@latest --kiro-dir docs
 ```
 
 ## 📁 Project Structure

--- a/tools/cc-sdd/README_ja.md
+++ b/tools/cc-sdd/README_ja.md
@@ -191,7 +191,7 @@ npx cc-sdd@latest --lang ja --os mac   # 旧来のフラグとして任意指定
 npx cc-sdd@latest --dry-run --backup
 
 # カスタムディレクトリ
-npx cc-sdd@latest --kiro-dir docs/specs
+npx cc-sdd@latest --kiro-dir docs
 ```
 
 ## 📁 プロジェクト構造

--- a/tools/cc-sdd/README_zh-TW.md
+++ b/tools/cc-sdd/README_zh-TW.md
@@ -188,7 +188,7 @@ npx cc-sdd@latest --lang zh-TW --os mac    # 保留的可選覆寫
 npx cc-sdd@latest --dry-run --backup
 
 # 自訂目錄
-npx cc-sdd@latest --kiro-dir docs/specs
+npx cc-sdd@latest --kiro-dir docs
 ```
 
 ## 📁 專案結構


### PR DESCRIPTION
## Summary
Fixed the `--kiro-dir` example in all README files to use `docs` instead of `docs/specs` to prevent confusing nested directory structure.

## Changes
- Updated README.md: `--kiro-dir docs/specs` → `--kiro-dir docs`
- Updated tools/cc-sdd/README.md: `--kiro-dir docs/specs` → `--kiro-dir docs`
- Updated tools/cc-sdd/README_ja.md: `--kiro-dir docs/specs` → `--kiro-dir docs`
- Updated tools/cc-sdd/README_zh-TW.md: `--kiro-dir docs/specs` → `--kiro-dir docs`

## Problem
When users followed the README example using `--kiro-dir docs/specs`, specification files were placed in `docs/specs/specs/`, creating a confusing nested structure.

## Solution
By using `--kiro-dir docs` instead, specification files will be placed in `docs/specs/`, which is clearer and more intuitive.

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)