### PR TITLE
Fix DEV_GUIDELINES tests in cc-sdd

### DIFF
--- a/tools/cc-sdd/test/templateContext.test.ts
+++ b/tools/cc-sdd/test/templateContext.test.ts
@@ -7,7 +7,9 @@ describe('buildTemplateContext', () => {
     const ctx = buildTemplateContext({ agent: 'claude-code', lang: 'ja' });
     expect(ctx.LANG_CODE).toBe('ja');
     expect(ctx.KIRO_DIR).toBe('.kiro');
-    expect(ctx.DEV_GUIDELINES).toBe('- Think in English, but generate responses in Japanese (思考は英語、回答の生成は日本語で行うように)');
+    expect(ctx.DEV_GUIDELINES).toBe(
+      '- Think in English, generate responses in Japanese. All Markdown content written to project files (e.g., requirements.md, design.md, tasks.md, research.md, validation reports) MUST be written in the target language configured for this specification (see spec.json.language).',
+    );
   });
 
   it('uses kiro-dir flag when provided', () => {

--- a/tools/cc-sdd/test/templateFromResolved.test.ts
+++ b/tools/cc-sdd/test/templateFromResolved.test.ts
@@ -16,7 +16,9 @@ describe('contextFromResolved', () => {
     expect(ctx.AGENT_DIR).toBe('.claude');
     expect(ctx.AGENT_DOC).toBe('CLAUDE.md');
     expect(ctx.AGENT_COMMANDS_DIR).toBe('.claude/commands/kiro');
-    expect(ctx.DEV_GUIDELINES).toBe('- Think in English, generate responses in English');
+    expect(ctx.DEV_GUIDELINES).toBe(
+      '- Think in English, generate responses in English. All Markdown content written to project files (e.g., requirements.md, design.md, tasks.md, research.md, validation reports) MUST be written in the target language configured for this specification (see spec.json.language).',
+    );
   });
 
   it('creates template context with custom configuration', () => {
@@ -34,7 +36,9 @@ describe('contextFromResolved', () => {
     expect(ctx.AGENT_DIR).toBe('.gemini');
     expect(ctx.AGENT_DOC).toBe('GEMINI.md');
     expect(ctx.AGENT_COMMANDS_DIR).toBe('.custom/commands');
-    expect(ctx.DEV_GUIDELINES).toBe('- Think in English, but generate responses in Japanese (思考は英語、回答の生成は日本語で行うように)');
+    expect(ctx.DEV_GUIDELINES).toBe(
+      '- Think in English, generate responses in Japanese. All Markdown content written to project files (e.g., requirements.md, design.md, tasks.md, research.md, validation reports) MUST be written in the target language configured for this specification (see spec.json.language).',
+    );
   });
 
   it('creates template context for qwen-code agent', () => {
@@ -47,7 +51,9 @@ describe('contextFromResolved', () => {
     expect(ctx.AGENT_DIR).toBe('.qwen');
     expect(ctx.AGENT_DOC).toBe('QWEN.md');
     expect(ctx.AGENT_COMMANDS_DIR).toBe('.qwen/commands/kiro');
-    expect(ctx.DEV_GUIDELINES).toBe('- 以英文思考，但以繁體中文生成回應（Think in English, generate in Traditional Chinese）');
+    expect(ctx.DEV_GUIDELINES).toBe(
+      '- Think in English, generate responses in Traditional Chinese. All Markdown content written to project files (e.g., requirements.md, design.md, tasks.md, research.md, validation reports) MUST be written in the target language configured for this specification (see spec.json.language).',
+    );
   });
 
   it('preserves all layout properties correctly', () => {
@@ -69,6 +75,8 @@ describe('contextFromResolved', () => {
     expect(ctx.AGENT_DIR).toBe('.custom-agent');
     expect(ctx.AGENT_DOC).toBe('CUSTOM-DOC.md');
     expect(ctx.AGENT_COMMANDS_DIR).toBe('.custom/commands/path');
-    expect(ctx.DEV_GUIDELINES).toBe('- Think in English, generate responses in English');
+    expect(ctx.DEV_GUIDELINES).toBe(
+      '- Think in English, generate responses in English. All Markdown content written to project files (e.g., requirements.md, design.md, tasks.md, research.md, validation reports) MUST be written in the target language configured for this specification (see spec.json.language).',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Update DEV_GUIDELINES expectations in cc-sdd Vitest tests to match the current guidelinesMap implementation.

## Why
- DEV guidelines text in src/template/context.ts was expanded to require all Markdown written to project files to use the spec's target language.
- Tests in templateContext.test.ts and templateFromResolved.test.ts still asserted the old, shorter strings and started failing.

## Impact
- Scope: test code under tools/cc-sdd/test only; no runtime or published package changes.
- Risk: very low; fixes npm test failures for v2.0.2 without altering behavior of cc-sdd itself.
- Non-goals: no version bump (remains v2.0.2) and no further wording changes beyond what is already implemented.