### PR TITLE
Fix DEV_GUIDELINES tests and update recommended models

### DIFF
--- a/tools/cc-sdd/src/agents/registry.ts
+++ b/tools/cc-sdd/src/agents/registry.ts
@@ -83,7 +83,7 @@ export const agentDefinitions = {
     description:
       'Installs kiro prompts in `.codex/prompts/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--codex', '--codex-cli'],
-    recommendedModels: ['GPT-5.1 high or medium'],
+    recommendedModels: ['gpt-5.1-codex medium/high', 'gpt-5.1 medium/high'],
     layout: {
       commandsDir: '.codex/prompts',
       agentDir: '.codex',
@@ -104,7 +104,11 @@ export const agentDefinitions = {
     description:
       'Installs kiro prompts in `.cursor/commands/kiro/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--cursor'],
-    recommendedModels: ['Claude 4.5 Sonnet thinking mode or newer', 'GPT-5.1 high or medium'],
+    recommendedModels: [
+      'Claude 4.5 Sonnet thinking mode or newer',
+      'gpt-5.1-codex medium/high',
+      'gpt-5.1 medium/high',
+    ],
     layout: {
       commandsDir: '.cursor/commands/kiro',
       agentDir: '.cursor',
@@ -122,7 +126,11 @@ export const agentDefinitions = {
     description:
       'Installs kiro prompts in `.github/prompts/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--copilot', '--github-copilot'],
-    recommendedModels: ['Claude 4.5 Sonnet thinking mode or newer', 'GPT-5.1 high or medium'],
+    recommendedModels: [
+      'Claude 4.5 Sonnet thinking mode or newer',
+      'gpt-5.1-codex medium/high',
+      'gpt-5.1 medium/high',
+    ],
     layout: {
       commandsDir: '.github/prompts',
       agentDir: '.github',
@@ -158,7 +166,7 @@ export const agentDefinitions = {
     description:
       'Installs kiro workflows in `.windsurf/workflows/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--windsurf'],
-    recommendedModels: ['Claude 4.5 Sonnet or newer', 'GPT-5.1 high or medium'],
+    recommendedModels: ['Claude 4.5 Sonnet or newer', 'gpt-5.1-codex medium/high', 'gpt-5.1 medium/high'],
     layout: {
       commandsDir: '.windsurf/workflows',
       agentDir: '.windsurf',


### PR DESCRIPTION
## Summary
- Fix DEV_GUIDELINES expectations in cc-sdd Vitest tests to match the current guidelinesMap implementation.
- Update agent registry recommendedModels entries to include GPT-5.1 Codex (medium/high) recommendations for Codex CLI, Cursor, GitHub Copilot, and Windsurf.

## Why
- DEV guidelines text in src/template/context.ts was expanded; tests were still asserting the older, shorter strings and failing.
- Dev guideline registry should reflect current recommended GPT-5.1 family models, including gpt-5.1-codex, for code-first workflows.

## Impact
- Scope: tools/cc-sdd test files and src/agents/registry.ts only; no runtime behavior change beyond model recommendation strings.
- Risk: very low; fixes npm test failures for v2.0.2 and improves documentation-style recommendations.
- Non-goals: no version bump (remains v2.0.2) and no additional wording changes beyond what is already implemented.