### PR TITLE
Release v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.3] - 2025-11-15
+
+### Changed
+- Refine recommended OpenAI models for Codex CLI, Cursor, GitHub Copilot, and Windsurf agents to prioritize `gpt-5.1-codex medium/high`, keeping `gpt-5.1 medium/high` as a general-purpose fallback.
+
+### Fixed
+- Align DEV_GUIDELINES-related tests with the stricter language-handling rules introduced in v2.0.2 so `npm test` passes cleanly for v2.0.3.
+
+- PRs: [#104](https://github.com/gotalab/cc-sdd/pull/104)
+
 ## [2.0.2] - 2025-11-15
 
 ### Changed

--- a/docs/RELEASE_NOTES/RELEASE_NOTES_en.md
+++ b/docs/RELEASE_NOTES/RELEASE_NOTES_en.md
@@ -6,7 +6,16 @@ New features and improvements for cc-sdd. See [CHANGELOG.md](../../CHANGELOG.md)
 
 ## 🔬 In Development (Unreleased)
 
-No unreleased features at this time. The latest stable release is v2.0.2.
+No unreleased features at this time. The latest stable release is v2.0.3.
+
+---
+
+## 📝 Ver 2.0.3 (2025-11-15) – GPT-5.1 Codex tuning
+
+- Refined recommended OpenAI models for Codex CLI, Cursor, GitHub Copilot, and Windsurf to explicitly include `gpt-5.1-codex medium/high` as the primary code-focused option, with `gpt-5.1 medium/high` as a general-purpose fallback.
+- Updated DEV_GUIDELINES-related tests so they match the stricter language-handling rules introduced in v2.0.2, keeping runtime behavior unchanged while ensuring `npm test` passes cleanly for v2.0.3.
+
+- Resources: [CHANGELOG.md](../../CHANGELOG.md#203---2025-11-15), PR: [#104](https://github.com/gotalab/cc-sdd/pull/104)
 
 ---
 

--- a/docs/RELEASE_NOTES/RELEASE_NOTES_ja.md
+++ b/docs/RELEASE_NOTES/RELEASE_NOTES_ja.md
@@ -6,7 +6,16 @@ cc-sddの新機能・改善情報をお届けします。技術的な変更履�
 
 ## 🔬 開発中 (Unreleased)
 
-現在、未リリースの機能はありません。最新の安定版はv2.0.2です。
+現在、未リリースの機能はありません。最新の安定版はv2.0.3です。
+
+---
+
+## 📝 Ver 2.0.3 (2025-11-15) - GPT-5.1 Codex向けの推奨モデル調整
+
+- Codex CLI / Cursor / GitHub Copilot / Windsurf 向けの推奨モデルに `gpt-5.1-codex medium/high` を明示的に追加し、コード中心のワークロードでは Codex 系モデルを優先しつつ、`gpt-5.1 medium/high` を汎用用途のフォールバックとして維持しました。
+- DEV_GUIDELINES 関連のテスト期待値を v2.0.2 で導入した厳密な言語ハンドリング仕様に合わせて修正し、ランタイム挙動を変えずに `npm test` がクリーンに通るようにしました。
+
+- リソース: [CHANGELOG.md](../../CHANGELOG.md#203---2025-11-15), PR: [#104](https://github.com/gotalab/cc-sdd/pull/104)
 
 ---
 

--- a/tools/cc-sdd/package.json
+++ b/tools/cc-sdd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-sdd",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Transform your coding workflow with AI-DLC and Spec-Driven Development. One command installs 11 powerful slash commands, Project Memory, and structured development workflows for 7 AI coding agents.",
   "keywords": ["claude-code", "cursor", "windsurf", "gemini-cli", "codex", "github-copilot", "qwen-code", "sdd", "spec-driven-development", "kiro", "steering", "ai-development", "tdd", "ai-dlc", "agentic-sdlc", "subagents", "parallel-tasks"],
   "author": "Gota",

--- a/tools/cc-sdd/test/realManifestCursor.test.ts
+++ b/tools/cc-sdd/test/realManifestCursor.test.ts
@@ -73,7 +73,8 @@ describe('real cursor manifest', () => {
     // Check that the Cursor-specific recommended models are shown
     expect(out).toContain('Recommended models');
     expect(out).toContain('Claude 4.5 Sonnet');
-    expect(out).toContain('GPT-5.1 high or medium');
+    expect(out).toContain('gpt-5.1-codex medium/high');
+    expect(out).toContain('gpt-5.1 medium/high');
 
     // Check that the unified next steps are present
     expect(out).toContain("Launch Cursor IDE and run `/kiro/spec-init <what-to-build>` to create a new specification.");

--- a/tools/cc-sdd/test/realManifestWindsurf.test.ts
+++ b/tools/cc-sdd/test/realManifestWindsurf.test.ts
@@ -68,7 +68,8 @@ describe('real windsurf manifest', () => {
     expect(out).toMatch(/Setup completed: written=\d+, skipped=\d+/);
     expect(out).toContain('Recommended models');
     expect(out).toContain('Claude 4.5 Sonnet');
-    expect(out).toContain('GPT-5.1 high or medium');
+    expect(out).toContain('gpt-5.1-codex medium/high');
+    expect(out).toContain('gpt-5.1 medium/high');
     expect(out).toContain('Launch Windsurf IDE and run `/kiro-spec-init <what-to-build>` to create a new specification.');
     expect(out).toMatch(
       /Tip: Steering holds persistent project knowledge—patterns, standards, and org-wide policies\. Kick off `\/kiro-steering` \(essential for existing projects\) and\s+`\/kiro-steering-custom <what-to-create-custom-steering-document>`\. Maintain Regularly/,


### PR DESCRIPTION
## Summary
- Bump cc-sdd to v2.0.3 and document the release in CHANGELOG and English/Japanese release notes.
- Refine recommended OpenAI models for Codex CLI, Cursor, GitHub Copilot, and Windsurf to include `gpt-5.1-codex medium/high` as the primary code-focused option.
- Update DEV_GUIDELINES-related tests and real manifest tests so `npm test` passes cleanly for v2.0.3.

## Why
- v2.0.2 introduced stricter language-handling and GPT-5.1 default model guidance; this patch aligns the dev guideline registry and tests with those expectations and the new GPT-5.1 Codex model family.

## Impact
- Scope: tools/cc-sdd package.json, tests, dev guideline registry, and docs (CHANGELOG + release notes).
- Risk: low; runtime changes are limited to recommended model strings in the registry, and all tests pass on v2.0.3.
- Non-goals: no behavioral changes to templates or CLI flags beyond model recommendation text.
