### PR TITLE
Fix prompt copy instruction in registry.ts

### DIFF
--- a/tools/cc-sdd/src/agents/registry.ts
+++ b/tools/cc-sdd/src/agents/registry.ts
@@ -29,7 +29,7 @@ export interface AgentDefinition {
 
 const codexCopyInstruction = String.raw`Move Codex Custom prompts to ~/.codex/prompts by running:
     mkdir -p ~/.codex/prompts \
-      && cp -Ri ./.codex/prompts/* ~/.codex/prompts/ \
+      && cp -Ri ./.codex/prompts/. ~/.codex/prompts/ \
       && printf '\n==== COPY PHASE DONE ====\n' \
       && printf 'Remove original ./.codex/prompts ? [y/N]: ' \
       && IFS= read -r a \


### PR DESCRIPTION
fix #98
Update "registry.ts" so that the copy command in the prompts directory works correctly when using Codex.
Please review the corrections and point them out if necessary. 
Thank you.