### PR TITLE
docs: add AI-Assisted SDD book reference to cc-sdd documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ npx cc-sdd@latest --kiro-dir docs
 🔗 **External Resources**
 - [Kiro IDE](https://kiro.dev) - Enhanced spec management and team collaboration
 - [Kiro's Spec Methodology](https://kiro.dev/docs/specs/) - Proven spec-driven development methodology
+- [AI-Assisted SDD: Spec-Driven Development with Gemini, Claude, and cc-sdd](https://www.amazon.com/dp/B0CW19YX9R) - Comprehensive book available on Amazon
 
 ## 📦 Package Information
 


### PR DESCRIPTION
Add reference to the comprehensive book on Spec-Driven Development with Gemini, Claude, and cc-sdd in the External Resources section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)