### PR TITLE
fix: update GitHub Copilot's prompt files to replace deprecated 'mode' attribute with 'agent'

### DIFF
--- a/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-spec-design.prompt.md
+++ b/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-spec-design.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: 'agent'
+agent: 'agent'
 description: 'Generate comprehensive technical design for a specification'
 ---
 <meta>

--- a/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-spec-impl.prompt.md
+++ b/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-spec-impl.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: 'agent'
+agent: 'agent'
 description: 'Execute spec tasks using TDD methodology'
 ---
 <meta>

--- a/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-spec-init.prompt.md
+++ b/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-spec-init.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: 'agent'
+agent: 'agent'
 description: Initialize a new specification with detailed project description
 ---
 <meta>

--- a/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-spec-requirements.prompt.md
+++ b/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-spec-requirements.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: 'agent'
+agent: 'agent'
 description: Generate comprehensive requirements for a specification
 ---
 <meta>

--- a/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-spec-status.prompt.md
+++ b/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-spec-status.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: 'agent'
+agent: 'agent'
 description: Show specification status and progress
 ---
 <meta>

--- a/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-spec-tasks.prompt.md
+++ b/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-spec-tasks.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: 'agent'
+agent: 'agent'
 description: Generate implementation tasks for a specification
 ---
 <meta>

--- a/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-steering-custom.prompt.md
+++ b/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-steering-custom.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: 'agent'
+agent: 'agent'
 description: Create custom steering documents for specialized project contexts
 ---
 <meta>

--- a/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-steering.prompt.md
+++ b/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-steering.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: 'agent'
+agent: 'agent'
 description: Manage {{KIRO_DIR}}/steering/ as persistent project knowledge
 ---
 <meta>

--- a/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-validate-design.prompt.md
+++ b/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-validate-design.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: 'agent'
+agent: 'agent'
 description: Interactive technical design quality review and validation
 ---
 <meta>

--- a/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-validate-gap.prompt.md
+++ b/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-validate-gap.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: 'agent'
+agent: 'agent'
 description: Analyze implementation gap between requirements and existing codebase
 ---
 <meta>

--- a/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-validate-impl.prompt.md
+++ b/tools/cc-sdd/templates/agents/github-copilot/commands/kiro-validate-impl.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: 'agent'
+agent: 'agent'
 description: Validate implementation against requirements, design, and tasks
 ---
 <meta>


### PR DESCRIPTION
## Summary

- Replace deprecated `mode` attribute with `agent` attribute in all GitHub Copilot prompt templates

## Context

- GitHub Copilot shows deprecation warnings when using `mode` in frontmatter (screenshot below)
  <img width="571" height="127" alt="github-copilot-deprecation-warning" src="https://github.com/user-attachments/assets/cbbb3d8d-c9c5-4f48-9680-dfb5f43150de" />
- Updated all kiro-* command templates to use the new `agent` attribute

## Impact

- Scope: GitHub Copilot agent templates only
- Risk: Very low; simple attribute rename with no behavior change