### PR TITLE
chore: bump version to 2.0.4

### DIFF
--- a/tools/cc-sdd/package-lock.json
+++ b/tools/cc-sdd/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-sdd",
-  "version": "1.0.0",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-sdd",
-      "version": "1.0.0",
+      "version": "2.0.4",
       "license": "MIT",
       "bin": {
         "cc-sdd": "dist/cli.js"

--- a/tools/cc-sdd/package.json
+++ b/tools/cc-sdd/package.json
@@ -1,8 +1,26 @@
 {
   "name": "cc-sdd",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Transform your coding workflow with AI-DLC and Spec-Driven Development. One command installs 11 powerful slash commands, Project Memory, and structured development workflows for 7 AI coding agents.",
-  "keywords": ["claude-code", "cursor", "windsurf", "gemini-cli", "codex", "github-copilot", "qwen-code", "sdd", "spec-driven-development", "kiro", "steering", "ai-development", "tdd", "ai-dlc", "agentic-sdlc", "subagents", "parallel-tasks"],
+  "keywords": [
+    "claude-code",
+    "cursor",
+    "windsurf",
+    "gemini-cli",
+    "codex",
+    "github-copilot",
+    "qwen-code",
+    "sdd",
+    "spec-driven-development",
+    "kiro",
+    "steering",
+    "ai-development",
+    "tdd",
+    "ai-dlc",
+    "agentic-sdlc",
+    "subagents",
+    "parallel-tasks"
+  ],
   "author": "Gota",
   "license": "MIT",
   "repository": {
@@ -10,7 +28,6 @@
     "url": "https://github.com/gotalab/cc-sdd.git",
     "directory": "tools/cc-sdd"
   },
-  
   "type": "module",
   "bin": {
     "cc-sdd": "./dist/cli.js"


### PR DESCRIPTION
package.jsonのバージョンを2.0.4に更新。v2.0.4タグでのnpm publish用。