### PR TITLE
docs: add release notes for v2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.4] - 2026-01-07
+
+### Fixed
+- Update GitHub Copilot prompt files to replace deprecated `mode` attribute with `agent` ([#118](https://github.com/gotalab/cc-sdd/pull/118))
+- Fix registry.ts with review improvements ([#107](https://github.com/gotalab/cc-sdd/pull/107))
+
+### Documentation
+- Add AI-Assisted SDD book reference to documentation ([#109](https://github.com/gotalab/cc-sdd/pull/109))
+
 ## [2.0.3] - 2025-11-15
 
 ### Changed

--- a/docs/RELEASE_NOTES/RELEASE_NOTES_en.md
+++ b/docs/RELEASE_NOTES/RELEASE_NOTES_en.md
@@ -6,7 +6,25 @@ New features and improvements for cc-sdd. See [CHANGELOG.md](../../CHANGELOG.md)
 
 ## 🔬 In Development (Unreleased)
 
-No unreleased features at this time. The latest stable release is v2.0.3.
+No unreleased features at this time. The latest stable release is v2.0.4.
+
+---
+
+## 📝 Ver 2.0.4 (2026-01-07) – Bug fixes & Documentation
+
+### Fixed
+- Updated GitHub Copilot prompt files to replace deprecated `mode` attribute with `agent` for compatibility with latest Copilot specifications.
+- Fixed registry.ts with review improvements.
+
+### Documentation
+- Added AI-Assisted SDD book reference to cc-sdd documentation.
+
+### New Contributors
+* @irisTa56 made their first contribution in #118
+* @leosamp made their first contribution in #109
+* @Kakenyan made their first contribution in #107
+
+- Resources: [CHANGELOG.md](../../CHANGELOG.md#204---2026-01-07), PRs: [#118](https://github.com/gotalab/cc-sdd/pull/118), [#109](https://github.com/gotalab/cc-sdd/pull/109), [#107](https://github.com/gotalab/cc-sdd/pull/107)
 
 ---
 

--- a/docs/RELEASE_NOTES/RELEASE_NOTES_ja.md
+++ b/docs/RELEASE_NOTES/RELEASE_NOTES_ja.md
@@ -6,7 +6,25 @@ cc-sddの新機能・改善情報をお届けします。技術的な変更履�
 
 ## 🔬 開発中 (Unreleased)
 
-現在、未リリースの機能はありません。最新の安定版はv2.0.3です。
+現在、未リリースの機能はありません。最新の安定版はv2.0.4です。
+
+---
+
+## 📝 Ver 2.0.4 (2026-01-07) - バグ修正 & ドキュメント更新
+
+### 修正
+- GitHub Copilotのプロンプトファイルで非推奨の`mode`属性を`agent`に置換し、最新のCopilot仕様に対応。
+- registry.tsのレビュー改善を反映。
+
+### ドキュメント
+- AI-Assisted SDDの書籍参照をドキュメントに追加。
+
+### 新規コントリビューター
+* @irisTa56 が #118 で初コントリビュート
+* @leosamp が #109 で初コントリビュート
+* @Kakenyan が #107 で初コントリビュート
+
+- リソース: [CHANGELOG.md](../../CHANGELOG.md#204---2026-01-07), PR: [#118](https://github.com/gotalab/cc-sdd/pull/118), [#109](https://github.com/gotalab/cc-sdd/pull/109), [#107](https://github.com/gotalab/cc-sdd/pull/107)
 
 ---
 


### PR DESCRIPTION
## Summary
- CHANGELOG.mdにv2.0.4エントリを追加
- RELEASE_NOTES_en.mdにv2.0.4セクションを追加
- RELEASE_NOTES_ja.mdにv2.0.4セクションを追加

v2.0.4リリース時にスキップしたドキュメント更新を追加します。