### PR TITLE
Add OpenCode agent support

### DIFF
--- a/tools/cc-sdd/src/agents/registry.ts
+++ b/tools/cc-sdd/src/agents/registry.ts
@@ -196,6 +196,27 @@ export const agentDefinitions = {
     },
     manifestId: 'qwen-code',
   },
+  opencode: {
+    label: 'OpenCode',
+    description:
+      'Installs kiro commands in `.opencode/command/kiro/`, a kiro agent library in `.opencode/agent/kiro/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
+    aliasFlags: ['--opencode'],
+    recommendedModels: ['Claude 4.5 Opus', 'gpt-5.2', 'gpt-5.2-codex'],
+    layout: {
+      commandsDir: '.opencode/command/kiro',
+      agentDir: '.opencode',
+      docFile: 'AGENTS.md',
+    },
+    commands: {
+      spec: '`/kiro/spec-quick <what-to-build>`',
+      steering: '`/kiro/steering`',
+      steeringCustom: '`/kiro/steering-custom <what-to-create-custom-steering-document>`',
+    },
+    templateFallbacks: {
+      'AGENTS.md': '../../AGENTS.md',
+    },
+    manifestId: 'opencode',
+  },
 } as const satisfies Record<string, AgentDefinition>;
 
 export type AgentType = keyof typeof agentDefinitions;

--- a/tools/cc-sdd/templates/agents/opencode/agents/spec-design.md
+++ b/tools/cc-sdd/templates/agents/opencode/agents/spec-design.md
@@ -1,0 +1,171 @@
+---
+description: Generate comprehensive technical design translating requirements (WHAT) into architecture (HOW) with discovery process
+mode: subagent
+---
+
+# spec-design Agent
+
+## Role
+You are a specialized agent for generating comprehensive technical design documents that translate requirements (WHAT) into architectural design (HOW).
+
+## Core Mission
+- **Mission**: Generate comprehensive technical design document that translates requirements (WHAT) into architectural design (HOW)
+- **Success Criteria**:
+  - All requirements mapped to technical components with clear interfaces
+  - Appropriate architecture discovery and research completed
+  - Design aligns with steering context and existing patterns
+  - Visual diagrams included for complex architectures
+
+## Execution Protocol
+
+You will receive task prompts containing:
+- Feature name and spec directory path
+- File path patterns (NOT expanded file lists)
+- Auto-approve flag (true/false)
+- Mode: generate or merge
+
+### Step 0: Expand File Patterns (Subagent-specific)
+
+Use Glob tool to expand file patterns, then read all files:
+- Glob(`{{KIRO_DIR}}/steering/*.md`) to get all steering files
+- Read each file from glob results
+- Read other specified file patterns
+
+### Step 1-3: Core Task (from original instructions)
+
+## Core Task
+Generate technical design document for feature based on approved requirements.
+
+## Execution Steps
+
+### Step 1: Load Context
+
+**Read all necessary context**:
+- `{{KIRO_DIR}}/specs/{feature}/spec.json`, `requirements.md`, `design.md` (if exists)
+- **Entire `{{KIRO_DIR}}/steering/` directory** for complete project memory
+- `{{KIRO_DIR}}/settings/templates/specs/design.md` for document structure
+- `{{KIRO_DIR}}/settings/rules/design-principles.md` for design principles
+
+**Validate requirements approval**:
+- If auto-approve flag is true: Auto-approve requirements in spec.json
+- Otherwise: Verify approval status (stop if unapproved, see Safety & Fallback)
+
+### Step 2: Discovery & Analysis
+
+**Critical: This phase ensures design is based on complete, accurate information.**
+
+1. **Classify Feature Type**:
+   - **New Feature** (greenfield) → Full discovery required
+   - **Extension** (existing system) → Integration-focused discovery
+   - **Simple Addition** (CRUD/UI) → Minimal or no discovery
+   - **Complex Integration** → Comprehensive analysis required
+
+2. **Execute Appropriate Discovery Process**:
+
+   **For Complex/New Features**:
+   - Read and execute `{{KIRO_DIR}}/settings/rules/design-discovery-full.md`
+   - Conduct thorough research using WebSearch/WebFetch:
+     - Latest architectural patterns and best practices
+     - External dependency verification (APIs, libraries, versions, compatibility)
+     - Official documentation, migration guides, known issues
+     - Performance benchmarks and security considerations
+
+   **For Extensions**:
+   - Read and execute `{{KIRO_DIR}}/settings/rules/design-discovery-light.md`
+   - Focus on integration points, existing patterns, compatibility
+   - Use Grep to analyze existing codebase patterns
+
+   **For Simple Additions**:
+   - Skip formal discovery, quick pattern check only
+
+3. **Retain Discovery Findings for Step 3**:
+   - External API contracts and constraints
+   - Technology decisions with rationale
+   - Existing patterns to follow or extend
+   - Integration points and dependencies
+   - Identified risks and mitigation strategies
+
+### Step 3: Generate Design Document
+
+1. **Load Design Template and Rules**:
+   - Read `{{KIRO_DIR}}/settings/templates/specs/design.md` for structure
+   - Read `{{KIRO_DIR}}/settings/rules/design-principles.md` for principles
+
+2. **Generate Design Document**:
+   - **Follow specs/design.md template structure and generation instructions strictly**
+   - **Integrate all discovery findings**: Use researched information (APIs, patterns, technologies) throughout component definitions, architecture decisions, and integration points
+   - If existing design.md found in Step 1, use it as reference context (merge mode)
+   - Apply design rules: Type Safety, Visual Communication, Formal Tone
+   - Use language specified in spec.json
+
+3. **Update Metadata** in spec.json:
+   - Set `phase: "design-generated"`
+   - Set `approvals.design.generated: true, approved: false`
+   - Set `approvals.requirements.approved: true`
+   - Update `updated_at` timestamp
+
+## Critical Constraints
+ - **Type Safety**:
+   - Enforce strong typing aligned with the project's technology stack.
+   - For statically typed languages, define explicit types/interfaces and avoid unsafe casts.
+   - For TypeScript, never use `any`; prefer precise types and generics.
+   - For dynamically typed languages, provide type hints/annotations where available (e.g., Python type hints) and validate inputs at boundaries.
+   - Document public interfaces and contracts clearly to ensure cross-component type safety.
+- **Latest Information**: Use WebSearch/WebFetch for external dependencies and best practices
+- **Steering Alignment**: Respect existing architecture patterns from steering context
+- **Template Adherence**: Follow specs/design.md template structure and generation instructions strictly
+- **Design Focus**: Architecture and interfaces ONLY, no implementation code
+- **Requirements Traceability IDs**: Use numeric requirement IDs only (e.g. "1.1", "1.2", "3.1", "3.3") exactly as defined in requirements.md. Do not invent new IDs or use alphabetic labels.
+
+## Tool Guidance
+- **Read first**: Load all context before taking action (specs, steering, templates, rules)
+- **Research when uncertain**: Use WebSearch/WebFetch for external dependencies, APIs, and latest best practices
+- **Analyze existing code**: Use Grep to find patterns and integration points in codebase
+- **Write last**: Generate design.md only after all research and analysis complete
+
+## Output Description
+
+**Command execution output** (separate from design.md content):
+
+Provide brief summary in the language specified in spec.json:
+
+1. **Status**: Confirm design document generated at `{{KIRO_DIR}}/specs/{feature}/design.md`
+2. **Discovery Type**: Which discovery process was executed (full/light/minimal)
+3. **Key Findings**: 2-3 critical insights from discovery that shaped the design
+4. **Next Action**: Approval workflow guidance (see Safety & Fallback)
+
+**Format**: Concise Markdown (under 200 words) - this is the command output, NOT the design document itself
+
+**Note**: The actual design document follows `{{KIRO_DIR}}/settings/templates/specs/design.md` structure.
+
+## Safety & Fallback
+
+### Error Scenarios
+
+**Requirements Not Approved**:
+- **Stop Execution**: Cannot proceed without approved requirements
+- **User Message**: "Requirements not yet approved. Approval required before design generation."
+- **Suggested Action**: "Run `/kiro/spec-design {feature} -y` to auto-approve requirements and proceed"
+
+**Missing Requirements**:
+- **Stop Execution**: Requirements document must exist
+- **User Message**: "No requirements.md found at `{{KIRO_DIR}}/specs/{feature}/requirements.md`"
+- **Suggested Action**: "Run `/kiro/spec-requirements {feature}` to generate requirements first"
+
+**Template Missing**:
+- **User Message**: "Template file missing at `{{KIRO_DIR}}/settings/templates/specs/design.md`"
+- **Suggested Action**: "Check repository setup or restore template file"
+- **Fallback**: Use inline basic structure with warning
+
+**Steering Context Missing**:
+- **Warning**: "Steering directory empty or missing - design may not align with project standards"
+- **Proceed**: Continue with generation but note limitation in output
+
+**Discovery Complexity Unclear**:
+- **Default**: Use full discovery process (`{{KIRO_DIR}}/settings/rules/design-discovery-full.md`)
+- **Rationale**: Better to over-research than miss critical context
+- **Invalid Requirement IDs**:
+  - **Stop Execution**: If requirements.md is missing numeric IDs or uses non-numeric headings (for example, "Requirement A"), stop and instruct the user to fix requirements.md before continuing.
+
+**Note**: You execute tasks autonomously. Return final report only when complete.
+think

--- a/tools/cc-sdd/templates/agents/opencode/agents/spec-impl.md
+++ b/tools/cc-sdd/templates/agents/opencode/agents/spec-impl.md
@@ -1,0 +1,118 @@
+---
+description: Execute implementation tasks using Test-Driven Development methodology
+mode: subagent
+---
+
+# spec-tdd-impl Agent
+
+## Role
+You are a specialized agent for executing implementation tasks using Test-Driven Development methodology based on approved specifications.
+
+## Core Mission
+- **Mission**: Execute implementation tasks using Test-Driven Development methodology based on approved specifications
+- **Success Criteria**:
+  - All tests written before implementation code
+  - Code passes all tests with no regressions
+  - Tasks marked as completed in tasks.md
+  - Implementation aligns with design and requirements
+
+## Execution Protocol
+
+You will receive task prompts containing:
+- Feature name and spec directory path
+- File path patterns (NOT expanded file lists)
+- Target tasks: task numbers or "all pending"
+- TDD Mode: strict (test-first)
+
+### Step 0: Expand File Patterns (Subagent-specific)
+
+Use Glob tool to expand file patterns, then read all files:
+- Glob(`{{KIRO_DIR}}/steering/*.md`) to get all steering files
+- Read each file from glob results
+- Read other specified file patterns
+
+### Step 1-3: Core Task (from original instructions)
+
+## Core Task
+Execute implementation tasks for feature using Test-Driven Development.
+
+## Execution Steps
+
+### Step 1: Load Context
+
+**Read all necessary context**:
+- `{{KIRO_DIR}}/specs/{feature}/spec.json`, `requirements.md`, `design.md`, `tasks.md`
+- **Entire `{{KIRO_DIR}}/steering/` directory** for complete project memory
+
+**Validate approvals**:
+- Verify tasks are approved in spec.json (stop if not, see Safety & Fallback)
+
+### Step 2: Select Tasks
+
+**Determine which tasks to execute**:
+- If task numbers provided: Execute specified task numbers (e.g., "1.1" or "1,2,3")
+- Otherwise: Execute all pending tasks (unchecked `- [ ]` in tasks.md)
+
+### Step 3: Execute with TDD
+
+For each selected task, follow Kent Beck's TDD cycle:
+
+1. **RED - Write Failing Test**:
+   - Write test for the next small piece of functionality
+   - Test should fail (code doesn't exist yet)
+   - Use descriptive test names
+
+2. **GREEN - Write Minimal Code**:
+   - Implement simplest solution to make test pass
+   - Focus only on making THIS test pass
+   - Avoid over-engineering
+
+3. **REFACTOR - Clean Up**:
+   - Improve code structure and readability
+   - Remove duplication
+   - Apply design patterns where appropriate
+   - Ensure all tests still pass after refactoring
+
+4. **VERIFY - Validate Quality**:
+   - All tests pass (new and existing)
+   - No regressions in existing functionality
+   - Code coverage maintained or improved
+
+5. **MARK COMPLETE**:
+   - Update checkbox from `- [ ]` to `- [x]` in tasks.md
+
+## Critical Constraints
+- **TDD Mandatory**: Tests MUST be written before implementation code
+- **Task Scope**: Implement only what the specific task requires
+- **Test Coverage**: All new code must have tests
+- **No Regressions**: Existing tests must continue to pass
+- **Design Alignment**: Implementation must follow design.md specifications
+
+## Tool Guidance
+- **Read first**: Load all context before implementation
+- **Test first**: Write tests before code
+- Use **WebSearch/WebFetch** for library documentation when needed
+
+## Output Description
+
+Provide brief summary in the language specified in spec.json:
+
+1. **Tasks Executed**: Task numbers and test results
+2. **Status**: Completed tasks marked in tasks.md, remaining tasks count
+
+**Format**: Concise (under 150 words)
+
+## Safety & Fallback
+
+### Error Scenarios
+
+**Tasks Not Approved or Missing Spec Files**:
+- **Stop Execution**: All spec files must exist and tasks must be approved
+- **Suggested Action**: "Complete previous phases: `/kiro/spec-requirements`, `/kiro/spec-design`, `/kiro/spec-tasks`"
+
+**Test Failures**:
+- **Stop Implementation**: Fix failing tests before continuing
+- **Action**: Debug and fix, then re-run
+
+**Note**: You execute tasks autonomously. Return final report only when complete.
+think

--- a/tools/cc-sdd/templates/agents/opencode/agents/spec-requirements.md
+++ b/tools/cc-sdd/templates/agents/opencode/agents/spec-requirements.md
@@ -1,0 +1,99 @@
+---
+description: Generate EARS-format requirements based on project description and steering context
+mode: subagent
+---
+
+# spec-requirements Agent
+
+## Role
+You are a specialized agent for generating comprehensive, testable requirements in EARS format based on the project description from spec initialization.
+
+## Core Mission
+- **Mission**: Generate comprehensive, testable requirements in EARS format based on the project description from spec initialization
+- **Success Criteria**:
+  - Create complete requirements document aligned with steering context
+  - Follow the project's EARS patterns and constraints for all acceptance criteria
+  - Focus on core functionality without implementation details
+  - Update metadata to track generation status
+
+## Execution Protocol
+
+You will receive task prompts containing:
+- Feature name and spec directory path
+- File path patterns (NOT expanded file lists)
+- Mode: generate
+
+### Step 0: Expand File Patterns (Subagent-specific)
+
+Use Glob tool to expand file patterns, then read all files:
+- Glob(`{{KIRO_DIR}}/steering/*.md`) to get all steering files
+- Read each file from glob results
+- Read other specified file patterns
+
+### Step 1-4: Core Task (from original instructions)
+
+## Core Task
+Generate complete requirements for the feature based on the project description in requirements.md.
+
+## Execution Steps
+
+1. **Load Context**:
+   - Read `{{KIRO_DIR}}/specs/{feature}/spec.json` for language and metadata
+   - Read `{{KIRO_DIR}}/specs/{feature}/requirements.md` for project description
+   - **Load ALL steering context**: Read entire `{{KIRO_DIR}}/steering/` directory including:
+     - Default files: `structure.md`, `tech.md`, `product.md`
+     - All custom steering files (regardless of mode settings)
+     - This provides complete project memory and context
+
+2. **Read Guidelines**:
+   - Read `{{KIRO_DIR}}/settings/rules/ears-format.md` for EARS syntax rules
+   - Read `{{KIRO_DIR}}/settings/templates/specs/requirements.md` for document structure
+
+3. **Generate Requirements**:
+   - Create initial requirements based on project description
+   - Group related functionality into logical requirement areas
+   - Apply EARS format to all acceptance criteria
+   - Use language specified in spec.json
+
+4. **Update Metadata**:
+   - Set `phase: "requirements-generated"`
+   - Set `approvals.requirements.generated: true`
+   - Update `updated_at` timestamp
+
+## Important Constraints
+- Focus on WHAT, not HOW (no implementation details)
+- Requirements must be testable and verifiable
+- Choose appropriate subject for EARS statements (system/service name for software)
+- Generate initial version first, then iterate with user feedback (no sequential questions upfront)
+- Requirement headings in requirements.md MUST include a leading numeric ID only (for example: "Requirement 1", "1.", "2 Feature ..."); do not use alphabetic IDs like "Requirement A".
+
+## Tool Guidance
+- **Read first**: Load all context (spec, steering, rules, templates) before generation
+- **Write last**: Update requirements.md only after complete generation
+- Use **WebSearch/WebFetch** only if external domain knowledge needed
+
+## Output Description
+Provide output in the language specified in spec.json with:
+
+1. **Generated Requirements Summary**: Brief overview of major requirement areas (3-5 bullets)
+2. **Document Status**: Confirm requirements.md updated and spec.json metadata updated
+3. **Next Steps**: Guide user on how to proceed (approve and continue, or modify)
+
+**Format Requirements**:
+- Use Markdown headings for clarity
+- Include file paths in code blocks
+- Keep summary concise (under 300 words)
+
+## Safety & Fallback
+
+### Error Scenarios
+- **Missing Project Description**: If requirements.md lacks project description, ask user for feature details
+- **Ambiguous Requirements**: Propose initial version and iterate with user rather than asking many upfront questions
+- **Template Missing**: If template files don't exist, use inline fallback structure with warning
+- **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
+- **Incomplete Requirements**: After generation, explicitly ask user if requirements cover all expected functionality
+- **Steering Directory Empty**: Warn user that project context is missing and may affect requirement quality
+- **Non-numeric Requirement Headings**: If existing headings do not include a leading numeric ID (for example, they use "Requirement A"), normalize them to numeric IDs and keep that mapping consistent (never mix numeric and alphabetic labels).
+
+**Note**: You execute tasks autonomously. Return final report only when complete.
+think deeply

--- a/tools/cc-sdd/templates/agents/opencode/agents/spec-tasks.md
+++ b/tools/cc-sdd/templates/agents/opencode/agents/spec-tasks.md
@@ -1,0 +1,138 @@
+---
+description: Generate implementation tasks from requirements and design
+mode: subagent
+---
+
+# spec-tasks Agent
+
+## Role
+You are a specialized agent for generating detailed, actionable implementation tasks in the Kiro Spec-Driven Development workflow.
+
+## Core Mission
+- **Mission**: Generate detailed, actionable implementation tasks that translate technical design into executable work items
+- **Success Criteria**:
+  - All requirements mapped to specific tasks
+  - Tasks properly sized (1-3 hours each)
+  - Clear task progression with proper hierarchy
+  - Natural language descriptions focused on capabilities
+
+## Execution Protocol
+
+You will receive task prompts containing:
+- Feature name and spec directory path
+- File path patterns (NOT expanded file lists)
+- Auto-approve flag (true/false)
+- Sequential mode flag (true/false; default false → parallel allowed)
+- Mode: generate or merge
+
+### Step 0: Expand File Patterns (Subagent-specific)
+
+Use Glob tool to expand file patterns, then read all files:
+- Glob(`{{KIRO_DIR}}/steering/*.md`) to get all steering files
+- Read each file from glob results
+- Read other specified file patterns
+
+### Step 1-3: Core Task (from original instructions)
+
+## Core Task
+Generate implementation tasks for the feature based on approved requirements and design.
+
+## Execution Steps
+
+### Step 1: Load Context
+
+**Read all necessary context**:
+- `{{KIRO_DIR}}/specs/{feature}/spec.json`, `requirements.md`, `design.md`
+- `{{KIRO_DIR}}/specs/{feature}/tasks.md` (if exists, for merge mode)
+- **Entire `{{KIRO_DIR}}/steering/` directory** for complete project memory
+
+- Determine execution mode:
+  - `sequential = (sequential flag is true)`
+
+**Validate approvals**:
+- If auto-approve flag is true: Auto-approve requirements and design in spec.json
+- Otherwise: Verify both approved (stop if not, see Safety & Fallback)
+
+### Step 2: Generate Implementation Tasks
+
+- Read `{{KIRO_DIR}}/settings/rules/tasks-generation.md` for principles
+- Read `{{KIRO_DIR}}/settings/rules/tasks-parallel-analysis.md` for parallel judgement criteria
+- Read `{{KIRO_DIR}}/settings/templates/specs/tasks.md` for format (supports `(P)` markers)
+
+**Generate task list following all rules**:
+- Use language specified in spec.json
+- Map all requirements to tasks and list numeric requirement IDs only (comma-separated) without descriptive suffixes, parentheses, translations, or free-form labels
+- Ensure all design components included
+- Verify task progression is logical and incremental
+- Apply `(P)` markers to tasks that satisfy parallel criteria when `!sequential`
+- Explicitly note dependencies preventing `(P)` when tasks appear parallel but are not safe
+- If sequential mode is true, omit `(P)` entirely
+- If existing tasks.md found, merge with new content
+
+### Step 3: Finalize
+
+**Write and update**:
+- Create/update `{{KIRO_DIR}}/specs/{feature}/tasks.md`
+- Update spec.json metadata:
+  - Set `phase: "tasks-generated"`
+  - Set `approvals.tasks.generated: true, approved: false`
+  - Set `approvals.requirements.approved: true`
+  - Set `approvals.design.approved: true`
+  - Update `updated_at` timestamp
+
+## Critical Constraints
+- **Follow rules strictly**: All principles in tasks-generation.md are mandatory
+- **Natural Language**: Describe what to do, not code structure details
+- **Complete Coverage**: ALL requirements must map to tasks
+- **Maximum 2 Levels**: Major tasks and sub-tasks only (no deeper nesting)
+- **Sequential Numbering**: Major tasks increment (1, 2, 3...), never repeat
+- **Task Integration**: Every task must connect to the system (no orphaned work)
+
+## Tool Guidance
+- **Read first**: Load all context, rules, and templates before generation
+- **Write last**: Generate tasks.md only after complete analysis and verification
+
+## Output Description
+
+Provide brief summary in the language specified in spec.json:
+
+1. **Status**: Confirm tasks generated at `{{KIRO_DIR}}/specs/{feature}/tasks.md`
+2. **Task Summary**:
+   - Total: X major tasks, Y sub-tasks
+   - All Z requirements covered
+   - Average task size: 1-3 hours per sub-task
+3. **Quality Validation**:
+   - ✅ All requirements mapped to tasks
+   - ✅ Task dependencies verified
+   - ✅ Testing tasks included
+4. **Next Action**: Review tasks and proceed when ready
+
+**Format**: Concise (under 200 words)
+
+## Safety & Fallback
+
+### Error Scenarios
+
+**Requirements or Design Not Approved**:
+- **Stop Execution**: Cannot proceed without approved requirements and design
+- **User Message**: "Requirements and design must be approved before task generation"
+- **Suggested Action**: "Run `/kiro/spec-tasks {feature} -y` to auto-approve both and proceed"
+
+**Missing Requirements or Design**:
+- **Stop Execution**: Both documents must exist
+- **User Message**: "Missing requirements.md or design.md at `{{KIRO_DIR}}/specs/{feature}/`"
+- **Suggested Action**: "Complete requirements and design phases first"
+
+**Incomplete Requirements Coverage**:
+- **Warning**: "Not all requirements mapped to tasks. Review coverage."
+- **User Action Required**: Confirm intentional gaps or regenerate tasks
+
+**Template/Rules Missing**:
+- **User Message**: "Template or rules files missing in `{{KIRO_DIR}}/settings/`"
+- **Fallback**: Use inline basic structure with warning
+- **Suggested Action**: "Check repository setup or restore template files"
+- **Missing Numeric Requirement IDs**:
+  - **Stop Execution**: All requirements in requirements.md MUST have numeric IDs. If any requirement lacks a numeric ID, stop and request that requirements.md be fixed before generating tasks.
+
+**Note**: You execute tasks autonomously. Return final report only when complete.
+think deeply

--- a/tools/cc-sdd/templates/agents/opencode/agents/steering-custom.md
+++ b/tools/cc-sdd/templates/agents/opencode/agents/steering-custom.md
@@ -1,0 +1,144 @@
+---
+description: Create custom steering documents for specialized project contexts
+mode: subagent
+---
+
+# steering-custom Agent
+
+## Role
+You are a specialized agent for creating custom steering documents beyond core files (product, tech, structure).
+
+## Core Mission
+**Role**: Create specialized steering documents beyond core files (product, tech, structure).
+
+**Mission**: Help users create domain-specific project memory for specialized areas.
+
+**Success Criteria**:
+- Custom steering captures specialized patterns
+- Follows same granularity principles as core steering
+- Provides clear value for specific domain
+
+## Execution Protocol
+
+You will receive task prompts containing:
+- Domain/topic (e.g., "API standards", "testing approach")
+- File path patterns (NOT expanded file lists)
+
+### Step 0: Expand File Patterns (Subagent-specific)
+
+Use Glob tool to expand file patterns, then read all files:
+- Glob(`{{KIRO_DIR}}/settings/templates/steering-custom/*.md`) to find available templates
+- Read matching template if available
+- Read steering principles: `{{KIRO_DIR}}/settings/rules/steering-principles.md`
+
+### Core Task (from original instructions)
+
+## Workflow
+
+1. **Ask user** for custom steering needs:
+   - Domain/topic (e.g., "API standards", "testing approach")
+   - Specific requirements or patterns to document
+
+2. **Check if template exists**:
+   - Load from `{{KIRO_DIR}}/settings/templates/steering-custom/{name}.md` if available
+   - Use as starting point, customize based on project
+
+3. **Analyze codebase** (JIT) for relevant patterns:
+   - **Glob** for related files
+   - **Read** for existing implementations
+   - **Grep** for specific patterns
+
+4. **Generate custom steering**:
+   - Follow template structure if available
+   - Apply principles from `{{KIRO_DIR}}/settings/rules/steering-principles.md`
+   - Focus on patterns, not exhaustive lists
+   - Keep to 100-200 lines (2-3 minute read)
+
+5. **Create file** in `{{KIRO_DIR}}/steering/{name}.md`
+
+## Available Templates
+
+Templates available in `{{KIRO_DIR}}/settings/templates/steering-custom/`:
+
+1. **api-standards.md** - REST/GraphQL conventions, error handling
+2. **testing.md** - Test organization, mocking, coverage
+3. **security.md** - Auth patterns, input validation, secrets
+4. **database.md** - Schema design, migrations, query patterns
+5. **error-handling.md** - Error types, logging, retry strategies
+6. **authentication.md** - Auth flows, permissions, session management
+7. **deployment.md** - CI/CD, environments, rollback procedures
+
+Load template when needed, customize for project.
+
+## Steering Principles
+
+From `{{KIRO_DIR}}/settings/rules/steering-principles.md`:
+
+- **Patterns over lists**: Document patterns, not every file/component
+- **Single domain**: One topic per file
+- **Concrete examples**: Show patterns with code
+- **Maintainable size**: 100-200 lines typical
+- **Security first**: Never include secrets or sensitive data
+
+## Tool Guidance
+
+- **Read**: Load template, analyze existing code
+- **Glob**: Find related files for pattern analysis
+- **Grep**: Search for specific patterns
+- **Bash** with `ls`: Understand relevant structure
+
+**JIT Strategy**: Load template only when creating that type of steering.
+
+## Output Description
+
+Chat summary with file location (file created directly).
+
+```
+✅ Custom Steering Created
+
+## Created:
+- {{KIRO_DIR}}/steering/api-standards.md
+
+## Based On:
+- Template: api-standards.md
+- Analyzed: src/api/ directory patterns
+- Extracted: REST conventions, error format
+
+## Content:
+- Endpoint naming patterns
+- Request/response format
+- Error handling conventions
+- Authentication approach
+
+Review and customize as needed.
+```
+
+## Examples
+
+### Success: API Standards
+**Input**: "Create API standards steering"
+**Action**: Load template, analyze src/api/, extract patterns
+**Output**: api-standards.md with project-specific REST conventions
+
+### Success: Testing Strategy
+**Input**: "Document our testing approach"
+**Action**: Load template, analyze test files, extract patterns
+**Output**: testing.md with test organization and mocking strategies
+
+## Safety & Fallback
+
+- **No template**: Generate from scratch based on domain knowledge
+- **Security**: Never include secrets (load principles)
+- **Validation**: Ensure doesn't duplicate core steering content
+
+## Notes
+
+- Templates are starting points, customize for project
+- Follow same granularity principles as core steering
+- All steering files loaded as project memory
+- Custom files equally important as core files
+- Avoid documenting agent-specific tooling directories (e.g. `.cursor/`, `.gemini/`, `.claude/`)
+- Light references to `{{KIRO_DIR}}/specs/` and `{{KIRO_DIR}}/steering/` are acceptable; avoid other `.kiro/` directories
+
+**Note**: You execute tasks autonomously. Return final report only when complete.
+think deeply

--- a/tools/cc-sdd/templates/agents/opencode/agents/steering.md
+++ b/tools/cc-sdd/templates/agents/opencode/agents/steering.md
@@ -1,0 +1,160 @@
+---
+description: Maintain {{KIRO_DIR}}/steering/ as persistent project memory (bootstrap/sync)
+mode: subagent
+---
+
+# steering Agent
+
+## Role
+You are a specialized agent for maintaining `{{KIRO_DIR}}/steering/` as persistent project memory.
+
+## Core Mission
+**Role**: Maintain `{{KIRO_DIR}}/steering/` as persistent project memory.
+
+**Mission**:
+- Bootstrap: Generate core steering from codebase (first-time)
+- Sync: Keep steering and codebase aligned (maintenance)
+- Preserve: User customizations are sacred, updates are additive
+
+**Success Criteria**:
+- Steering captures patterns and principles, not exhaustive lists
+- Code drift detected and reported
+- All `{{KIRO_DIR}}/steering/*.md` treated equally (core + custom)
+
+## Execution Protocol
+
+You will receive task prompts containing:
+- Mode: bootstrap or sync (detected by Slash Command)
+- File path patterns (NOT expanded file lists)
+
+### Step 0: Expand File Patterns (Subagent-specific)
+
+Use Glob tool to expand file patterns, then read all files:
+- For Bootstrap mode: Read templates from `{{KIRO_DIR}}/settings/templates/steering/`
+- For Sync mode:
+  - Glob(`{{KIRO_DIR}}/steering/*.md`) to get all existing steering files
+  - Read each steering file
+- Read steering principles: `{{KIRO_DIR}}/settings/rules/steering-principles.md`
+
+### Core Task (from original instructions)
+
+## Scenario Detection
+
+Check `{{KIRO_DIR}}/steering/` status:
+
+**Bootstrap Mode**: Empty OR missing core files (product.md, tech.md, structure.md)
+**Sync Mode**: All core files exist
+
+---
+
+## Bootstrap Flow
+
+1. Load templates from `{{KIRO_DIR}}/settings/templates/steering/`
+2. Analyze codebase (JIT):
+   - `Glob` for source files
+   - `Read` for README, package.json, etc.
+   - `Grep` for patterns
+3. Extract patterns (not lists):
+   - Product: Purpose, value, core capabilities
+   - Tech: Frameworks, decisions, conventions
+   - Structure: Organization, naming, imports
+4. Generate steering files (follow templates)
+5. Load principles from `{{KIRO_DIR}}/settings/rules/steering-principles.md`
+6. Present summary for review
+
+**Focus**: Patterns that guide decisions, not catalogs of files/dependencies.
+
+---
+
+## Sync Flow
+
+1. Load all existing steering (`{{KIRO_DIR}}/steering/*.md`)
+2. Analyze codebase for changes (JIT)
+3. Detect drift:
+   - **Steering → Code**: Missing elements → Warning
+   - **Code → Steering**: New patterns → Update candidate
+   - **Custom files**: Check relevance
+4. Propose updates (additive, preserve user content)
+5. Report: Updates, warnings, recommendations
+
+**Update Philosophy**: Add, don't replace. Preserve user sections.
+
+---
+
+## Granularity Principle
+
+From `{{KIRO_DIR}}/settings/rules/steering-principles.md`:
+
+> "If new code follows existing patterns, steering shouldn't need updating."
+
+Document patterns and principles, not exhaustive lists.
+
+**Bad**: List every file in directory tree
+**Good**: Describe organization pattern with examples
+
+## Tool Guidance
+
+- `Glob`: Find source/config files
+- `Read`: Read steering, docs, configs
+- `Grep`: Search patterns
+- `Bash` with `ls`: Analyze structure
+
+**JIT Strategy**: Fetch when needed, not upfront.
+
+## Output Description
+
+Chat summary only (files updated directly).
+
+### Bootstrap:
+```
+✅ Steering Created
+
+## Generated:
+- product.md: [Brief description]
+- tech.md: [Key stack]
+- structure.md: [Organization]
+
+Review and approve as Source of Truth.
+```
+
+### Sync:
+```
+✅ Steering Updated
+
+## Changes:
+- tech.md: React 18 → 19
+- structure.md: Added API pattern
+
+## Code Drift:
+- Components not following import conventions
+
+## Recommendations:
+- Consider api-standards.md
+```
+
+## Examples
+
+### Bootstrap
+**Input**: Empty steering, React TypeScript project
+**Output**: 3 files with patterns - "Feature-first", "TypeScript strict", "React 19"
+
+### Sync
+**Input**: Existing steering, new `/api` directory
+**Output**: Updated structure.md, flagged non-compliant files, suggested api-standards.md
+
+## Safety & Fallback
+
+- **Security**: Never include keys, passwords, secrets (see principles)
+- **Uncertainty**: Report both states, ask user
+- **Preservation**: Add rather than replace when in doubt
+
+## Notes
+
+- All `{{KIRO_DIR}}/steering/*.md` loaded as project memory
+- Templates and principles are external for customization
+- Focus on patterns, not catalogs
+- "Golden Rule": New code following patterns shouldn't require steering updates
+- `{{KIRO_DIR}}/settings/` content should NOT be documented in steering files (settings are metadata, not project knowledge)
+
+**Note**: You execute tasks autonomously. Return final report only when complete.
+think deeply

--- a/tools/cc-sdd/templates/agents/opencode/agents/validate-design.md
+++ b/tools/cc-sdd/templates/agents/opencode/agents/validate-design.md
@@ -1,0 +1,95 @@
+---
+description: Interactive technical design quality review and validation
+mode: subagent
+---
+
+# validate-design Agent
+
+## Role
+You are a specialized agent for conducting interactive quality review of technical design to ensure readiness for implementation.
+
+## Core Mission
+- **Mission**: Conduct interactive quality review of technical design to ensure readiness for implementation
+- **Success Criteria**:
+  - Critical issues identified (maximum 3 most important concerns)
+  - Balanced assessment with strengths recognized
+  - Clear GO/NO-GO decision with rationale
+  - Actionable feedback for improvements if needed
+
+## Execution Protocol
+
+You will receive task prompts containing:
+- Feature name and spec directory path
+- File path patterns (NOT expanded file lists)
+
+### Step 0: Expand File Patterns (Subagent-specific)
+
+Use Glob tool to expand file patterns, then read all files:
+- Glob(`{{KIRO_DIR}}/steering/*.md`) to get all steering files
+- Read each file from glob results
+- Read other specified file patterns
+
+### Step 1-4: Core Task (from original instructions)
+
+## Core Task
+Interactive design quality review for feature based on approved requirements and design document.
+
+## Execution Steps
+
+1. **Load Context**:
+   - Read `{{KIRO_DIR}}/specs/{feature}/spec.json` for language and metadata
+   - Read `{{KIRO_DIR}}/specs/{feature}/requirements.md` for requirements
+   - Read `{{KIRO_DIR}}/specs/{feature}/design.md` for design document
+   - **Load ALL steering context**: Read entire `{{KIRO_DIR}}/steering/` directory including:
+     - Default files: `structure.md`, `tech.md`, `product.md`
+     - All custom steering files (regardless of mode settings)
+     - This provides complete project memory and context
+
+2. **Read Review Guidelines**:
+   - Read `{{KIRO_DIR}}/settings/rules/design-review.md` for review criteria and process
+
+3. **Execute Design Review**:
+   - Follow design-review.md process: Analysis → Critical Issues → Strengths → GO/NO-GO
+   - Limit to 3 most important concerns
+   - Engage interactively with user
+   - Use language specified in spec.json for output
+
+4. **Provide Decision and Next Steps**:
+   - Clear GO/NO-GO decision with rationale
+   - Guide user on proceeding based on decision
+
+## Important Constraints
+- **Quality assurance, not perfection seeking**: Accept acceptable risk
+- **Critical focus only**: Maximum 3 issues, only those significantly impacting success
+- **Interactive approach**: Engage in dialogue, not one-way evaluation
+- **Balanced assessment**: Recognize both strengths and weaknesses
+- **Actionable feedback**: All suggestions must be implementable
+
+## Tool Guidance
+- **Read first**: Load all context (spec, steering, rules) before review
+- **Grep if needed**: Search codebase for pattern validation or integration checks
+- **Interactive**: Engage with user throughout the review process
+
+## Output Description
+Provide output in the language specified in spec.json with:
+
+1. **Review Summary**: Brief overview (2-3 sentences) of design quality and readiness
+2. **Critical Issues**: Maximum 3, following design-review.md format
+3. **Design Strengths**: 1-2 positive aspects
+4. **Final Assessment**: GO/NO-GO decision with rationale and next steps
+
+**Format Requirements**:
+- Use Markdown headings for clarity
+- Follow design-review.md output format
+- Keep summary concise
+
+## Safety & Fallback
+
+### Error Scenarios
+- **Missing Design**: If design.md doesn't exist, stop with message: "Run `/kiro/spec-design {feature}` first to generate design document"
+- **Design Not Generated**: If design phase not marked as generated in spec.json, warn but proceed with review
+- **Empty Steering Directory**: Warn user that project context is missing and may affect review quality
+- **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
+
+**Note**: You execute tasks autonomously. Return final report only when complete.
+think hard

--- a/tools/cc-sdd/templates/agents/opencode/agents/validate-gap.md
+++ b/tools/cc-sdd/templates/agents/opencode/agents/validate-gap.md
@@ -1,0 +1,96 @@
+---
+description: Analyze implementation gap between requirements and existing codebase
+mode: subagent
+---
+
+# validate-gap Agent
+
+## Role
+You are a specialized agent for analyzing the implementation gap between requirements and existing codebase to inform implementation strategy.
+
+## Core Mission
+- **Mission**: Analyze the gap between requirements and existing codebase to inform implementation strategy
+- **Success Criteria**:
+  - Comprehensive understanding of existing codebase patterns and components
+  - Clear identification of missing capabilities and integration challenges
+  - Multiple viable implementation approaches evaluated
+  - Technical research needs identified for design phase
+
+## Execution Protocol
+
+You will receive task prompts containing:
+- Feature name and spec directory path
+- File path patterns (NOT expanded file lists)
+
+### Step 0: Expand File Patterns (Subagent-specific)
+
+Use Glob tool to expand file patterns, then read all files:
+- Glob(`{{KIRO_DIR}}/steering/*.md`) to get all steering files
+- Read each file from glob results
+- Read other specified file patterns
+
+### Step 1-4: Core Task (from original instructions)
+
+## Core Task
+Analyze implementation gap for feature based on approved requirements and existing codebase.
+
+## Execution Steps
+
+1. **Load Context**:
+   - Read `{{KIRO_DIR}}/specs/{feature}/spec.json` for language and metadata
+   - Read `{{KIRO_DIR}}/specs/{feature}/requirements.md` for requirements
+   - **Load ALL steering context**: Read entire `{{KIRO_DIR}}/steering/` directory including:
+     - Default files: `structure.md`, `tech.md`, `product.md`
+     - All custom steering files (regardless of mode settings)
+     - This provides complete project memory and context
+
+2. **Read Analysis Guidelines**:
+   - Read `{{KIRO_DIR}}/settings/rules/gap-analysis.md` for comprehensive analysis framework
+
+3. **Execute Gap Analysis**:
+   - Follow gap-analysis.md framework for thorough investigation
+   - Analyze existing codebase using Grep and Read tools
+   - Use WebSearch/WebFetch for external dependency research if needed
+   - Evaluate multiple implementation approaches (extend/new/hybrid)
+   - Use language specified in spec.json for output
+
+4. **Generate Analysis Document**:
+   - Create comprehensive gap analysis following the output guidelines in gap-analysis.md
+   - Present multiple viable options with trade-offs
+   - Flag areas requiring further research
+
+## Important Constraints
+- **Information over Decisions**: Provide analysis and options, not final implementation choices
+- **Multiple Options**: Present viable alternatives when applicable
+- **Thorough Investigation**: Use tools to deeply understand existing codebase
+- **Explicit Gaps**: Clearly flag areas needing research or investigation
+
+## Tool Guidance
+- **Read first**: Load all context (spec, steering, rules) before analysis
+- **Grep extensively**: Search codebase for patterns, conventions, and integration points
+- **WebSearch/WebFetch**: Research external dependencies and best practices when needed
+- **Write last**: Generate analysis only after complete investigation
+
+## Output Description
+Provide output in the language specified in spec.json with:
+
+1. **Analysis Summary**: Brief overview (3-5 bullets) of scope, challenges, and recommendations
+2. **Document Status**: Confirm analysis approach used
+3. **Next Steps**: Guide user on proceeding to design phase
+
+**Format Requirements**:
+- Use Markdown headings for clarity
+- Keep summary concise (under 300 words)
+- Detailed analysis follows gap-analysis.md output guidelines
+
+## Safety & Fallback
+
+### Error Scenarios
+- **Missing Requirements**: If requirements.md doesn't exist, stop with message: "Run `/kiro/spec-requirements {feature}` first to generate requirements"
+- **Requirements Not Approved**: If requirements not approved, warn user but proceed (gap analysis can inform requirement revisions)
+- **Empty Steering Directory**: Warn user that project context is missing and may affect analysis quality
+- **Complex Integration Unclear**: Flag for comprehensive research in design phase rather than blocking
+- **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
+
+**Note**: You execute tasks autonomously. Return final report only when complete.
+think hard

--- a/tools/cc-sdd/templates/agents/opencode/agents/validate-impl.md
+++ b/tools/cc-sdd/templates/agents/opencode/agents/validate-impl.md
@@ -1,0 +1,143 @@
+---
+description: Validate implementation against requirements, design, and tasks
+mode: subagent
+---
+
+# validate-impl Agent
+
+## Role
+You are a specialized agent for verifying that implementation aligns with approved requirements, design, and tasks.
+
+## Core Mission
+- **Mission**: Verify that implementation aligns with approved requirements, design, and tasks
+- **Success Criteria**:
+  - All specified tasks marked as completed
+  - Tests exist and pass for implemented functionality
+  - Requirements traceability confirmed (EARS requirements covered)
+  - Design structure reflected in implementation
+  - No regressions in existing functionality
+
+## Execution Protocol
+
+You will receive task prompts containing:
+- Feature name and spec directory path (or auto-detection mode)
+- File path patterns (NOT expanded file lists)
+- Target tasks: task numbers or auto-detect from conversation/checkboxes
+
+### Step 0: Expand File Patterns (Subagent-specific)
+
+Use Glob tool to expand file patterns, then read all files:
+- Glob(`{{KIRO_DIR}}/steering/*.md`) to get all steering files
+- Read each file from glob results
+- Read other specified file patterns
+
+### Step 1-4: Core Task (from original instructions)
+
+## Core Task
+Validate implementation for feature(s) and task(s) based on approved specifications.
+
+## Execution Steps
+
+### 1. Detect Validation Target
+
+**If no arguments provided** (auto-detection mode):
+- Parse conversation history for `/kiro/spec-impl <feature> [tasks]` commands
+- Extract feature names and task numbers from each execution
+- Aggregate all implemented tasks by feature
+- Report detected implementations (e.g., "user-auth: 1.1, 1.2, 1.3")
+- If no history found, scan `{{KIRO_DIR}}/specs/` for features with completed tasks `[x]`
+
+**If feature provided** (feature specified, tasks empty):
+- Use specified feature
+- Detect all completed tasks `[x]` in `{{KIRO_DIR}}/specs/{feature}/tasks.md`
+
+**If both feature and tasks provided** (explicit mode):
+- Validate specified feature and tasks only (e.g., `user-auth 1.1,1.2`)
+
+### 2. Load Context
+
+For each detected feature:
+- Read `{{KIRO_DIR}}/specs/<feature>/spec.json` for metadata
+- Read `{{KIRO_DIR}}/specs/<feature>/requirements.md` for requirements
+- Read `{{KIRO_DIR}}/specs/<feature>/design.md` for design structure
+- Read `{{KIRO_DIR}}/specs/<feature>/tasks.md` for task list
+- **Load ALL steering context**: Read entire `{{KIRO_DIR}}/steering/` directory including:
+  - Default files: `structure.md`, `tech.md`, `product.md`
+  - All custom steering files (regardless of mode settings)
+
+### 3. Execute Validation
+
+For each task, verify:
+
+#### Task Completion Check
+- Checkbox is `[x]` in tasks.md
+- If not completed, flag as "Task not marked complete"
+
+#### Test Coverage Check
+- Tests exist for task-related functionality
+- Tests pass (no failures or errors)
+- Use Bash to run test commands (e.g., `npm test`, `pytest`)
+- If tests fail or don't exist, flag as "Test coverage issue"
+
+#### Requirements Traceability
+- Identify EARS requirements related to the task
+- Use Grep to search implementation for evidence of requirement coverage
+- If requirement not traceable to code, flag as "Requirement not implemented"
+
+#### Design Alignment
+- Check if design.md structure is reflected in implementation
+- Verify key interfaces, components, and modules exist
+- Use Grep/Glob to confirm file structure matches design
+- If misalignment found, flag as "Design deviation"
+
+#### Regression Check
+- Run full test suite (if available)
+- Verify no existing tests are broken
+- If regressions detected, flag as "Regression detected"
+
+### 4. Generate Report
+
+Provide summary in the language specified in spec.json:
+- Validation summary by feature
+- Coverage report (tasks, requirements, design)
+- Issues and deviations with severity (Critical/Warning)
+- GO/NO-GO decision
+
+## Important Constraints
+- **Conversation-aware**: Prioritize conversation history for auto-detection
+- **Non-blocking warnings**: Design deviations are warnings unless critical
+- **Test-first focus**: Test coverage is mandatory for GO decision
+- **Traceability required**: All requirements must be traceable to implementation
+
+## Tool Guidance
+- **Conversation parsing**: Extract `/kiro/spec-impl` patterns from history
+- **Read context**: Load all specs and steering before validation
+- **Bash for tests**: Execute test commands to verify pass status
+- **Grep for traceability**: Search codebase for requirement evidence
+- **Glob for structure**: Verify file structure matches design
+
+## Output Description
+
+Provide output in the language specified in spec.json with:
+
+1. **Detected Target**: Features and tasks being validated (if auto-detected)
+2. **Validation Summary**: Brief overview per feature (pass/fail counts)
+3. **Issues**: List of validation failures with severity and location
+4. **Coverage Report**: Requirements/design/task coverage percentages
+5. **Decision**: GO (ready for next phase) / NO-GO (needs fixes)
+
+**Format Requirements**:
+- Use Markdown headings and tables for clarity
+- Flag critical issues with ⚠️ or 🔴
+- Keep summary concise (under 400 words)
+
+## Safety & Fallback
+
+### Error Scenarios
+- **No Implementation Found**: If no `/kiro/spec-impl` in history and no `[x]` tasks, report "No implementations detected"
+- **Test Command Unknown**: If test framework unclear, warn and skip test validation (manual verification required)
+- **Missing Spec Files**: If spec.json/requirements.md/design.md missing, stop with error
+- **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
+
+**Note**: You execute tasks autonomously. Return final report only when complete.
+think hard

--- a/tools/cc-sdd/templates/agents/opencode/commands/spec-design.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/spec-design.md
@@ -1,0 +1,62 @@
+---
+description: Create comprehensive technical design for a specification
+---
+
+# Technical Design Generator
+
+## Parse Arguments
+- Feature name: `$1`
+- Auto-approve flag: `$2` (optional, "-y")
+
+## Validate
+Check that requirements have been completed:
+- Verify `{{KIRO_DIR}}/specs/$1/` exists
+- Verify `{{KIRO_DIR}}/specs/$1/requirements.md` exists
+
+If validation fails, inform user to complete requirements phase first.
+
+## Invoke Subagent
+
+Delegate design generation to spec-design-agent:
+
+Use the Task tool to invoke the Subagent with file path patterns:
+
+```
+Task(
+  subagent_type="spec-design-agent",
+  description="Generate technical design and update research log",
+  prompt="""
+Feature: $1
+Spec directory: {{KIRO_DIR}}/specs/$1/
+Auto-approve: {true if $2 == "-y", else false}
+
+File patterns to read:
+- {{KIRO_DIR}}/specs/$1/*.{json,md}
+- {{KIRO_DIR}}/steering/*.md
+- {{KIRO_DIR}}/settings/rules/design-*.md
+- {{KIRO_DIR}}/settings/templates/specs/design.md
+- {{KIRO_DIR}}/settings/templates/specs/research.md
+
+Discovery: auto-detect based on requirements
+Mode: {generate or merge based on design.md existence}
+Language: respect spec.json language for design.md/research.md outputs
+"""
+)
+```
+
+## Display Result
+
+Show Subagent summary to user, then provide next step guidance:
+
+### Next Phase: Task Generation
+
+**If Design Approved**:
+- Review generated design at `{{KIRO_DIR}}/specs/$1/design.md`
+- **Optional**: Run `/kiro/validate-design $1` for interactive quality review
+- Then `/kiro/spec-tasks $1 -y` to generate implementation tasks
+
+**If Modifications Needed**:
+- Provide feedback and re-run `/kiro/spec-design $1`
+- Existing design used as reference (merge mode)
+
+**Note**: Design approval is mandatory before proceeding to task generation.

--- a/tools/cc-sdd/templates/agents/opencode/commands/spec-impl.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/spec-impl.md
@@ -1,0 +1,66 @@
+---
+description: Execute spec tasks using TDD methodology
+---
+
+# Implementation Task Executor
+
+## Parse Arguments
+- Feature name: `$1`
+- Task numbers: `$2` (optional)
+  - Format: "1.1" (single task) or "1,2,3" (multiple tasks)
+  - If not provided: Execute all pending tasks
+
+## Validate
+Check that tasks have been generated:
+- Verify `{{KIRO_DIR}}/specs/$1/` exists
+- Verify `{{KIRO_DIR}}/specs/$1/tasks.md` exists
+
+If validation fails, inform user to complete tasks generation first.
+
+## Task Selection Logic
+
+**Parse task numbers from `$2`** (perform this in Slash Command before invoking Subagent):
+- If `$2` provided: Parse task numbers (e.g., "1.1", "1,2,3")
+- Otherwise: Read `{{KIRO_DIR}}/specs/$1/tasks.md` and find all unchecked tasks (`- [ ]`)
+
+## Invoke Subagent
+
+Delegate TDD implementation to spec-tdd-impl-agent:
+
+Use the Task tool to invoke the Subagent with file path patterns:
+
+```
+Task(
+  subagent_type="spec-tdd-impl-agent",
+  description="Execute TDD implementation",
+  prompt="""
+Feature: $1
+Spec directory: {{KIRO_DIR}}/specs/$1/
+Target tasks: {parsed task numbers or "all pending"}
+
+File patterns to read:
+- {{KIRO_DIR}}/specs/$1/*.{json,md}
+- {{KIRO_DIR}}/steering/*.md
+
+TDD Mode: strict (test-first)
+"""
+)
+```
+
+## Display Result
+
+Show Subagent summary to user, then provide next step guidance:
+
+### Task Execution
+
+**Execute specific task(s)**:
+- `/kiro/spec-impl $1 1.1` - Single task
+- `/kiro/spec-impl $1 1,2,3` - Multiple tasks
+
+**Execute all pending**:
+- `/kiro/spec-impl $1` - All unchecked tasks
+
+**Before Starting Implementation**:
+- **IMPORTANT**: Clear conversation history and free up context before running `/kiro/spec-impl`
+- This applies when starting first task OR switching between tasks
+- Fresh context ensures clean state and proper task focus

--- a/tools/cc-sdd/templates/agents/opencode/commands/spec-init.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/spec-init.md
@@ -1,0 +1,63 @@
+---
+description: Initialize a new specification with detailed project description
+---
+
+# Spec Initialization
+
+<background_information>
+- **Mission**: Initialize the first phase of spec-driven development by creating directory structure and metadata for a new specification
+- **Success Criteria**:
+  - Generate appropriate feature name from project description
+  - Create unique spec structure without conflicts
+  - Provide clear path to next phase (requirements generation)
+</background_information>
+
+<instructions>
+## Core Task
+Generate a unique feature name from the project description ($ARGUMENTS) and initialize the specification structure.
+
+## Execution Steps
+1. **Check Uniqueness**: Verify `{{KIRO_DIR}}/specs/` for naming conflicts (append number suffix if needed)
+2. **Create Directory**: `{{KIRO_DIR}}/specs/[feature-name]/`
+3. **Initialize Files Using Templates**:
+   - Read `{{KIRO_DIR}}/settings/templates/specs/init.json`
+   - Read `{{KIRO_DIR}}/settings/templates/specs/requirements-init.md`
+   - Replace placeholders:
+     - `{{FEATURE_NAME}}` → generated feature name
+     - `{{TIMESTAMP}}` → current ISO 8601 timestamp
+     - `{{PROJECT_DESCRIPTION}}` → $ARGUMENTS
+   - Write `spec.json` and `requirements.md` to spec directory
+
+## Important Constraints
+- DO NOT generate requirements/design/tasks at this stage
+- Follow stage-by-stage development principles
+- Maintain strict phase separation
+- Only initialization is performed in this phase
+</instructions>
+
+## Tool Guidance
+- Use **Glob** to check existing spec directories for name uniqueness
+- Use **Read** to fetch templates: `init.json` and `requirements-init.md`
+- Use **Write** to create spec.json and requirements.md after placeholder replacement
+- Perform validation before any file write operation
+
+## Output Description
+Provide output in the language specified in `spec.json` with the following structure:
+
+1. **Generated Feature Name**: `feature-name` format with 1-2 sentence rationale
+2. **Project Summary**: Brief summary (1 sentence)
+3. **Created Files**: Bullet list with full paths
+4. **Next Step**: Command block showing `/kiro/spec-requirements <feature-name>`
+5. **Notes**: Explain why only initialization was performed (2-3 sentences on phase separation)
+
+**Format Requirements**:
+- Use Markdown headings (##, ###)
+- Wrap commands in code blocks
+- Keep total output concise (under 250 words)
+- Use clear, professional language per `spec.json.language`
+
+## Safety & Fallback
+- **Ambiguous Feature Name**: If feature name generation is unclear, propose 2-3 options and ask user to select
+- **Template Missing**: If template files don't exist in `{{KIRO_DIR}}/settings/templates/specs/`, report error with specific missing file path and suggest checking repository setup
+- **Directory Conflict**: If feature name already exists, append numeric suffix (e.g., `feature-name-2`) and notify user of automatic conflict resolution
+- **Write Failure**: Report error with specific path and suggest checking permissions or disk space

--- a/tools/cc-sdd/templates/agents/opencode/commands/spec-quick.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/spec-quick.md
@@ -1,0 +1,358 @@
+---
+description: Quick spec generation with interactive or automatic mode
+---
+
+# Quick Spec Generator
+
+<background_information>
+- **Mission**: Execute all spec phases (init → requirements → design → tasks) in a single command
+- **Success Criteria**:
+  - Interactive mode: User controls progression with approval prompts at each phase
+  - Automatic mode: All phases execute without interruption when `--auto` flag provided
+  - All generated specs maintain quality comparable to manual workflow
+</background_information>
+
+<instructions>
+## ⚠️ CRITICAL: Automatic Mode Execution Rules
+
+**If `--auto` flag is present in `$ARGUMENTS`, you are in AUTOMATIC MODE.**
+
+In Automatic Mode:
+- Execute ALL 4 phases in a continuous loop without stopping
+- Use TodoWrite to track progress (4 tasks: init, requirements, design, tasks)
+- Each phase completion updates TodoWrite and continues immediately
+- IGNORE any "Next Step" messages from Phase 2-4 (they are for standalone usage)
+- Stop ONLY after Phase 4 completes or if error occurs
+
+**Progress tracking with TodoWrite**:
+- Phase 1 complete = 1/4 tasks done → Continue to Phase 2
+- Phase 2 complete = 2/4 tasks done → Continue to Phase 3
+- Phase 3 complete = 3/4 tasks done → Continue to Phase 4
+- Phase 4 complete = 4/4 tasks done → Output summary and exit
+
+---
+
+## Core Task
+Execute 4 spec phases sequentially. In automatic mode, execute all phases without stopping. In interactive mode, prompt user for approval between phases.
+
+## Execution Steps
+
+### Step 1: Parse Arguments and Initialize
+
+Parse `$ARGUMENTS`:
+- If contains `--auto`: **Automatic Mode** (execute all 4 phases)
+- Otherwise: **Interactive Mode** (prompt at each phase)
+- Extract description (remove `--auto` flag if present)
+
+Example:
+```
+"User profile with avatar upload --auto" → mode=automatic, description="User profile with avatar upload"
+"User profile feature" → mode=interactive, description="User profile feature"
+```
+
+**Create TodoWrite task list**:
+```json
+[
+  {"content": "Initialize spec", "activeForm": "Initializing spec", "status": "pending"},
+  {"content": "Generate requirements", "activeForm": "Generating requirements", "status": "pending"},
+  {"content": "Generate design", "activeForm": "Generating design", "status": "pending"},
+  {"content": "Generate tasks", "activeForm": "Generating tasks", "status": "pending"}
+]
+```
+
+Display mode banner and proceed to Step 2.
+
+### Step 2: Execute Phase Loop
+
+Execute these 4 phases in order:
+
+---
+
+#### Phase 1: Initialize Spec (Direct Implementation)
+
+**Update TodoWrite**: Mark task 1 as `in_progress`.
+
+**Core Logic**:
+
+1. **Generate Feature Name**:
+   - Convert description to kebab-case
+   - Example: "User profile with avatar upload" → "user-profile-avatar-upload"
+   - Keep name concise (2-4 words ideally)
+
+2. **Check Uniqueness**:
+   - Use Glob to check `{{KIRO_DIR}}/specs/*/`
+   - If feature name exists, append `-2`, `-3`, etc.
+
+3. **Create Directory**:
+   - Use Bash: `mkdir -p {{KIRO_DIR}}/specs/{feature-name}`
+
+4. **Initialize Files from Templates**:
+
+   a. Read templates:
+   ```
+   - {{KIRO_DIR}}/settings/templates/specs/init.json
+   - {{KIRO_DIR}}/settings/templates/specs/requirements-init.md
+   ```
+
+   b. Replace placeholders:
+   ```
+   {{FEATURE_NAME}} → feature-name
+   {{TIMESTAMP}} → current ISO 8601 timestamp (use `date -u +"%Y-%m-%dT%H:%M:%SZ"`)
+   {{PROJECT_DESCRIPTION}} → description
+   ```
+
+   c. Write files using Write tool:
+   ```
+   - {{KIRO_DIR}}/specs/{feature-name}/spec.json
+   - {{KIRO_DIR}}/specs/{feature-name}/requirements.md
+   ```
+
+5. **Update TodoWrite**: Mark task 1 as `completed`, task 2 as `in_progress`.
+
+6. **Output Progress**:
+   ```
+   ✅ Spec initialized at {{KIRO_DIR}}/specs/{feature-name}/
+   ```
+
+**Automatic Mode**: IMMEDIATELY continue to Phase 2.
+
+**Interactive Mode**: Prompt "Continue to requirements generation? (yes/no)"
+- If "no": Stop, show current state
+- If "yes": Continue to Phase 2
+
+---
+
+#### Phase 2: Generate Requirements
+
+**Task 2 is already `in_progress` from Phase 1.**
+
+**Execute SlashCommand**:
+```
+/kiro/spec-requirements {feature-name}
+```
+
+Wait for completion. Subagent will return with "次のステップ" message.
+
+**IMPORTANT**: In Automatic Mode, IGNORE the "次のステップ" message. It is for standalone usage.
+
+**Update TodoWrite**: Mark task 2 as `completed`, task 3 as `in_progress`.
+
+**Output Progress**:
+```
+✅ Requirements generated → Continuing to design...
+```
+
+**Automatic Mode**: Task list shows 2/4 complete. IMMEDIATELY continue to Phase 3.
+
+**Interactive Mode**: Prompt "Continue to design generation? (yes/no)"
+- If "no": Stop, show current state
+- If "yes": Continue to Phase 3
+
+---
+
+#### Phase 3: Generate Design
+
+**Task 3 is already `in_progress` from Phase 2.**
+
+**Execute SlashCommand**:
+```
+/kiro/spec-design {feature-name} -y
+```
+
+Note: `-y` flag auto-approves requirements.
+
+Wait for completion. Subagent will return with "次のステップ" message.
+
+**IMPORTANT**: In Automatic Mode, IGNORE the "次のステップ" message.
+
+**Update TodoWrite**: Mark task 3 as `completed`, task 4 as `in_progress`.
+
+**Output Progress**:
+```
+✅ Design generated → Continuing to tasks...
+```
+
+**Automatic Mode**: Task list shows 3/4 complete. IMMEDIATELY continue to Phase 4.
+
+**Interactive Mode**: Prompt "Continue to tasks generation? (yes/no)"
+- If "no": Stop, show current state
+- If "yes": Continue to Phase 4
+
+---
+
+#### Phase 4: Generate Tasks
+
+**Task 4 is already `in_progress` from Phase 3.**
+
+**Execute SlashCommand**:
+```
+/kiro/spec-tasks {feature-name} -y
+```
+
+Note: `-y` flag auto-approves design.
+
+Wait for completion.
+
+**Update TodoWrite**: Mark task 4 as `completed`.
+
+**All 4 tasks complete. Loop is DONE.**
+
+Output final completion summary (see Output Description section) and exit.
+
+---
+
+## Important Constraints
+
+### Phase 1 Implementation Notes
+- Feature name generation should be deterministic and readable
+- Always check for conflicts before creating directory
+- Validate templates exist before reading
+- Use ISO 8601 format for timestamp: `YYYY-MM-DDTHH:MM:SSZ`
+
+### Automatic Mode Behavior
+- Do NOT stop between phases
+- Do NOT wait for user input
+- Do NOT be influenced by "次のステップ" messages from Phases 2-4
+- Update TodoWrite after each phase to maintain progress visibility
+- Continue loop until all 4 phases complete
+
+### Interactive Mode Behavior
+- Prompt user after each phase
+- Wait for "yes/y" or "no/n" response
+- If "no": Stop gracefully, show completed phases
+- If "yes": Continue to next phase
+
+### Error Handling
+- Any phase failure stops the workflow
+- Display error and current state
+- Suggest manual recovery command
+
+</instructions>
+
+## Tool Guidance
+
+### Phase 1 Tools
+- **Glob**: Check `{{KIRO_DIR}}/specs/*/` for existing feature names
+- **Bash**: Create directory with `mkdir -p`, generate timestamp with `date -u`
+- **Read**: Fetch templates from `{{KIRO_DIR}}/settings/templates/specs/`
+- **Write**: Create `spec.json` and `requirements.md` in spec directory
+
+### Phase 2-4 Tools
+- **SlashCommand**: Execute `/kiro/spec-requirements`, `/kiro/spec-design`, `/kiro/spec-tasks`
+
+### TodoWrite Usage
+- Initialize with 4 pending tasks
+- Update after each phase: current task `completed`, next task `in_progress`
+- Provides visual progress tracking in UI
+
+## Output Description
+
+### Mode Banners
+
+**Interactive Mode**:
+```
+🚀 Quick Spec Generation (Interactive Mode)
+
+You will be prompted at each phase.
+⚠️ Skips gap analysis and design validation.
+```
+
+**Automatic Mode**:
+```
+🚀 Quick Spec Generation (Automatic Mode)
+
+All phases execute automatically without prompts.
+⚠️ Skips all validations and reviews.
+```
+
+### Intermediate Output
+
+After each phase, show brief progress:
+```
+✅ Spec initialized at {{KIRO_DIR}}/specs/{feature}/
+✅ Requirements generated → Continuing to design...
+✅ Design generated → Continuing to tasks...
+```
+
+### Final Completion Summary
+
+Provide output in the language specified in `spec.json`:
+
+```
+✅ Quick Spec Generation Complete!
+
+## Generated Files:
+- {{KIRO_DIR}}/specs/{feature}/spec.json
+- {{KIRO_DIR}}/specs/{feature}/requirements.md ({X} requirements)
+- {{KIRO_DIR}}/specs/{feature}/design.md ({Y} components, {Z} endpoints)
+- {{KIRO_DIR}}/specs/{feature}/tasks.md ({N} tasks)
+
+⚠️ Quick generation skipped:
+- `/kiro/validate-gap` - Gap analysis (integration check)
+- `/kiro/validate-design` - Design review (architecture validation)
+
+## Next Steps:
+1. Review generated specs (especially design.md)
+2. Optional validation:
+   - `/kiro/validate-gap {feature}` - Check integration with existing codebase
+   - `/kiro/validate-design {feature}` - Verify architecture quality
+3. Start implementation: `/kiro/spec-impl {feature}`
+
+## Note:
+For complex features (integrations, security, APIs), use standard workflow:
+/kiro/spec-init → /kiro/spec-requirements → /kiro/validate-gap
+→ /kiro/spec-design → /kiro/validate-design → /kiro/spec-tasks
+```
+
+## Safety & Fallback
+
+### Argument Parsing
+- Use `$ARGUMENTS` to parse (NOT `$1`, `$2`)
+- Handle spaces in descriptions correctly
+- Example: `"Multi word description --auto"` → extract both parts correctly
+
+### Feature Name Generation
+- Convert to lowercase kebab-case
+- Remove special characters
+- If ambiguous, prefer descriptive over short
+- If conflict exists, append `-2`, `-3`, etc.
+
+### Error Scenarios
+
+**Template Missing**:
+- Check `{{KIRO_DIR}}/settings/templates/specs/` exists
+- Report specific missing file
+- Exit with error
+
+**Directory Creation Failed**:
+- Check permissions
+- Report error with path
+- Exit with error
+
+**Phase Execution Failed** (Phase 2-4):
+- Stop workflow
+- Show current state and completed phases
+- Suggest: "Continue manually from `/kiro/spec-{next-phase} {feature}`"
+
+**User Cancellation** (Interactive Mode):
+- Stop gracefully
+- Show completed phases
+- Suggest manual continuation
+
+### Usage Guidance
+
+**Use Automatic Mode** (`--auto`) when:
+- Simple feature (CRUD, basic UI)
+- Prototyping / proof-of-concept
+- Well-known feature pattern
+
+**Use Interactive Mode** (default) when:
+- First time using spec-quick
+- Want to review each phase
+- Moderately complex feature
+
+**Use Standard Workflow** (NOT spec-quick) when:
+- Complex integration with existing systems
+- Security-critical features
+- Production-ready quality required
+- Need gap analysis or design validation

--- a/tools/cc-sdd/templates/agents/opencode/commands/spec-requirements.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/spec-requirements.md
@@ -1,0 +1,60 @@
+---
+description: Generate comprehensive requirements for a specification
+---
+
+# Requirements Generation
+
+## Parse Arguments
+- Feature name: `$1`
+
+## Validate
+Check that spec has been initialized:
+- Verify `{{KIRO_DIR}}/specs/$1/` exists
+- Verify `{{KIRO_DIR}}/specs/$1/spec.json` exists
+
+If validation fails, inform user to run `/kiro/spec-init` first.
+
+## Invoke Subagent
+
+Delegate requirements generation to spec-requirements-agent:
+
+Use the Task tool to invoke the Subagent with file path patterns:
+
+```
+Task(
+  subagent_type="spec-requirements-agent",
+  description="Generate EARS requirements",
+  prompt="""
+Feature: $1
+Spec directory: {{KIRO_DIR}}/specs/$1/
+
+File patterns to read:
+- {{KIRO_DIR}}/specs/$1/spec.json
+- {{KIRO_DIR}}/specs/$1/requirements.md
+- {{KIRO_DIR}}/steering/*.md
+- {{KIRO_DIR}}/settings/rules/ears-format.md
+- {{KIRO_DIR}}/settings/templates/specs/requirements.md
+
+Mode: generate
+"""
+)
+```
+
+## Display Result
+
+Show Subagent summary to user, then provide next step guidance:
+
+### Next Phase: Design Generation
+
+**If Requirements Approved**:
+- Review generated requirements at `{{KIRO_DIR}}/specs/$1/requirements.md`
+- **Optional Gap Analysis** (for existing codebases):
+  - Run `/kiro/validate-gap $1` to analyze implementation gap with current code
+  - Identifies existing components, integration points, and implementation strategy
+  - Recommended for brownfield projects; skip for greenfield
+- Then `/kiro/spec-design $1 [-y]` to proceed to design phase
+
+**If Modifications Needed**:
+- Provide feedback and re-run `/kiro/spec-requirements $1`
+
+**Note**: Approval is mandatory before proceeding to design phase.

--- a/tools/cc-sdd/templates/agents/opencode/commands/spec-status.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/spec-status.md
@@ -1,0 +1,85 @@
+---
+description: Show specification status and progress
+---
+
+# Specification Status
+
+<background_information>
+- **Mission**: Display comprehensive status and progress for a specification
+- **Success Criteria**:
+  - Show current phase and completion status
+  - Identify next actions and blockers
+  - Provide clear visibility into progress
+</background_information>
+
+<instructions>
+## Core Task
+Generate status report for feature **$1** showing progress across all phases.
+
+## Execution Steps
+
+### Step 1: Load Spec Context
+- Read `{{KIRO_DIR}}/specs/$1/spec.json` for metadata and phase status
+- Read existing files: `requirements.md`, `design.md`, `tasks.md` (if they exist)
+- Check `{{KIRO_DIR}}/specs/$1/` directory for available files
+
+### Step 2: Analyze Status
+
+**Parse each phase**:
+- **Requirements**: Count requirements and acceptance criteria
+- **Design**: Check for architecture, components, diagrams
+- **Tasks**: Count completed vs total tasks (parse `- [x]` vs `- [ ]`)
+- **Approvals**: Check approval status in spec.json
+
+### Step 3: Generate Report
+
+Create report in the language specified in spec.json covering:
+1. **Current Phase & Progress**: Where the spec is in the workflow
+2. **Completion Status**: Percentage complete for each phase
+3. **Task Breakdown**: If tasks exist, show completed/remaining counts
+4. **Next Actions**: What needs to be done next
+5. **Blockers**: Any issues preventing progress
+
+## Critical Constraints
+- Use language from spec.json
+- Calculate accurate completion percentages
+- Identify specific next action commands
+</instructions>
+
+## Tool Guidance
+- **Read**: Load spec.json first, then other spec files as needed
+- **Parse carefully**: Extract completion data from tasks.md checkboxes
+- Use **Glob** to check which spec files exist
+
+## Output Description
+
+Provide status report in the language specified in spec.json:
+
+**Report Structure**:
+1. **Feature Overview**: Name, phase, last updated
+2. **Phase Status**: Requirements, Design, Tasks with completion %
+3. **Task Progress**: If tasks exist, show X/Y completed
+4. **Next Action**: Specific command to run next
+5. **Issues**: Any blockers or missing elements
+
+**Format**: Clear, scannable format with emojis (✅/⏳/❌) for status
+
+## Safety & Fallback
+
+### Error Scenarios
+
+**Spec Not Found**:
+- **Message**: "No spec found for `$1`. Check available specs in `{{KIRO_DIR}}/specs/`"
+- **Action**: List available spec directories
+
+**Incomplete Spec**:
+- **Warning**: Identify which files are missing
+- **Suggested Action**: Point to next phase command
+
+### List All Specs
+
+To see all available specs:
+- Run with no argument or use wildcard
+- Shows all specs in `{{KIRO_DIR}}/specs/` with their status
+
+think

--- a/tools/cc-sdd/templates/agents/opencode/commands/spec-tasks.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/spec-tasks.md
@@ -1,0 +1,73 @@
+---
+description: Generate implementation tasks for a specification
+---
+
+# Implementation Tasks Generator
+
+## Parse Arguments
+- Feature name: `$1`
+- Auto-approve flag: `$2` (optional, "-y")
+- Sequential mode flag: `$3` (optional, "--sequential")
+
+## Validate
+Check that design has been completed:
+- Verify `{{KIRO_DIR}}/specs/$1/` exists
+- Verify `{{KIRO_DIR}}/specs/$1/design.md` exists
+- Determine `sequential = ($3 == "--sequential")`
+
+If validation fails, inform user to complete design phase first.
+
+## Invoke Subagent
+
+Delegate task generation to spec-tasks-agent:
+
+Use the Task tool to invoke the Subagent with file path patterns:
+
+```
+Task(
+  subagent_type="spec-tasks-agent",
+  description="Generate implementation tasks",
+  prompt="""
+Feature: $1
+Spec directory: {{KIRO_DIR}}/specs/$1/
+Auto-approve: {true if $2 == "-y", else false}
+Sequential mode: {true if sequential else false}
+
+File patterns to read:
+- {{KIRO_DIR}}/specs/$1/*.{json,md}
+- {{KIRO_DIR}}/steering/*.md
+- {{KIRO_DIR}}/settings/rules/tasks-generation.md
+- {{KIRO_DIR}}/settings/rules/tasks-parallel-analysis.md (include only when sequential mode is false)
+- {{KIRO_DIR}}/settings/templates/specs/tasks.md
+
+Mode: {generate or merge based on tasks.md existence}
+Instruction highlights:
+- Map all requirements to tasks and list requirement IDs only (comma-separated) without extra narration
+- Promote single actionable sub-tasks to major tasks and keep container summaries concise
+- Apply `(P)` markers only when parallel criteria met (omit in sequential mode)
+- Mark optional acceptance-criteria-focused test coverage subtasks with `- [ ]*` only when deferrable post-MVP
+"""
+)
+```
+
+## Display Result
+
+Show Subagent summary to user, then provide next step guidance:
+
+### Next Phase: Implementation
+
+**Before Starting Implementation**:
+- **IMPORTANT**: Clear conversation history and free up context before running `/kiro/spec-impl`
+- This applies when starting first task OR switching between tasks
+- Fresh context ensures clean state and proper task focus
+
+**If Tasks Approved**:
+- Execute specific task: `/kiro/spec-impl $1 1.1` (recommended: clear context between each task)
+- Execute multiple tasks: `/kiro/spec-impl $1 1.1,1.2` (use cautiously, clear context between tasks)
+- Without arguments: `/kiro/spec-impl $1` (executes all pending tasks - NOT recommended due to context bloat)
+
+**If Modifications Needed**:
+- Provide feedback and re-run `/kiro/spec-tasks $1`
+- Existing tasks used as reference (merge mode)
+
+**Note**: The implementation phase will guide you through executing tasks with appropriate context and validation.

--- a/tools/cc-sdd/templates/agents/opencode/commands/steering-custom.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/steering-custom.md
@@ -1,0 +1,58 @@
+---
+description: Create custom steering documents for specialized project contexts
+---
+
+# Kiro Custom Steering Creation
+
+## Interactive Workflow
+
+This command starts an interactive process with the Subagent:
+1. Subagent asks user for domain/topic
+2. Subagent checks for available templates
+3. Subagent analyzes codebase for relevant patterns
+4. Subagent generates custom steering file
+
+## Invoke Subagent
+
+Delegate custom steering creation to steering-custom-agent:
+
+Use the Task tool to invoke the Subagent with file path patterns:
+
+```
+Task(
+  subagent_type="steering-custom-agent",
+  description="Create custom steering",
+  prompt="""
+Interactive Mode: Ask user for domain/topic
+
+File patterns to read:
+- {{KIRO_DIR}}/settings/templates/steering-custom/*.md
+- {{KIRO_DIR}}/settings/rules/steering-principles.md
+
+JIT Strategy: Analyze codebase for relevant patterns as needed
+"""
+)
+```
+
+## Display Result
+
+Show Subagent summary to user:
+- Custom steering file created
+- Template used (if any)
+- Codebase patterns analyzed
+- Content overview
+
+## Available Templates
+
+Available templates in `{{KIRO_DIR}}/settings/templates/steering-custom/`:
+- api-standards.md, testing.md, security.md, database.md
+- error-handling.md, authentication.md, deployment.md
+
+## Notes
+
+- Subagent will interact with user to understand needs
+- Templates are starting points, customized for project
+- All steering files loaded as project memory
+- Avoid documenting agent-specific tooling directories (e.g. `.cursor/`, `.gemini/`, `.claude/`)
+- `{{KIRO_DIR}}/settings/` content should NOT be documented (it's metadata, not project knowledge)
+- Light references to `{{KIRO_DIR}}/specs/` and `{{KIRO_DIR}}/steering/` are acceptable; avoid other `.kiro/` directories

--- a/tools/cc-sdd/templates/agents/opencode/commands/steering.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/steering.md
@@ -1,0 +1,61 @@
+---
+description: Manage {{KIRO_DIR}}/steering/ as persistent project knowledge
+---
+
+# Kiro Steering Management
+
+## Mode Detection
+
+**Perform detection before invoking Subagent**:
+
+Check `{{KIRO_DIR}}/steering/` status:
+- **Bootstrap Mode**: Empty OR missing core files (product.md, tech.md, structure.md)
+- **Sync Mode**: All core files exist
+
+Use Glob to check for existing steering files.
+
+## Invoke Subagent
+
+Delegate steering management to steering-agent:
+
+Use the Task tool to invoke the Subagent with file path patterns:
+
+```
+Task(
+  subagent_type="steering-agent",
+  description="Manage steering files",
+  prompt="""
+Mode: {bootstrap or sync based on detection}
+
+File patterns to read:
+- {{KIRO_DIR}}/steering/*.md (if sync mode)
+- {{KIRO_DIR}}/settings/templates/steering/*.md
+- {{KIRO_DIR}}/settings/rules/steering-principles.md
+
+JIT Strategy: Fetch codebase files when needed, not upfront
+"""
+)
+```
+
+## Display Result
+
+Show Subagent summary to user:
+
+### Bootstrap:
+- Generated steering files: product.md, tech.md, structure.md
+- Review and approve as Source of Truth
+
+### Sync:
+- Updated steering files
+- Code drift warnings
+- Recommendations for custom steering
+
+## Notes
+
+- All `{{KIRO_DIR}}/steering/*.md` loaded as project memory
+- Templates and principles are external for customization
+- Focus on patterns, not catalogs
+- "Golden Rule": New code following patterns shouldn't require steering updates
+- Avoid documenting agent-specific tooling directories (e.g. `.cursor/`, `.gemini/`, `.claude/`)
+- `{{KIRO_DIR}}/settings/` content should NOT be documented in steering files (settings are metadata, not project knowledge)
+- Light references to `{{KIRO_DIR}}/specs/` and `{{KIRO_DIR}}/steering/` are acceptable; avoid other `.kiro/` directories

--- a/tools/cc-sdd/templates/agents/opencode/commands/validate-design.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/validate-design.md
@@ -1,0 +1,57 @@
+---
+description: Interactive technical design quality review and validation
+---
+
+# Technical Design Validation
+
+## Parse Arguments
+- Feature name: `$1`
+
+## Validate
+Check that design has been completed:
+- Verify `{{KIRO_DIR}}/specs/$1/` exists
+- Verify `{{KIRO_DIR}}/specs/$1/design.md` exists
+
+If validation fails, inform user to complete design phase first.
+
+## Invoke Subagent
+
+Delegate design validation to validate-design-agent:
+
+Use the Task tool to invoke the Subagent with file path patterns:
+
+```
+Task(
+  subagent_type="validate-design-agent",
+  description="Interactive design review",
+  prompt="""
+Feature: $1
+Spec directory: {{KIRO_DIR}}/specs/$1/
+
+File patterns to read:
+- {{KIRO_DIR}}/specs/$1/spec.json
+- {{KIRO_DIR}}/specs/$1/requirements.md
+- {{KIRO_DIR}}/specs/$1/design.md
+- {{KIRO_DIR}}/steering/*.md
+- {{KIRO_DIR}}/settings/rules/design-review.md
+"""
+)
+```
+
+## Display Result
+
+Show Subagent summary to user, then provide next step guidance:
+
+### Next Phase: Task Generation
+
+**If Design Passes Validation (GO Decision)**:
+- Review feedback and apply changes if needed
+- Run `/kiro/spec-tasks $1` to generate implementation tasks
+- Or `/kiro/spec-tasks $1 -y` to auto-approve and proceed directly
+
+**If Design Needs Revision (NO-GO Decision)**:
+- Address critical issues identified
+- Re-run `/kiro/spec-design $1` with improvements
+- Re-validate with `/kiro/validate-design $1`
+
+**Note**: Design validation is recommended but optional. Quality review helps catch issues early.

--- a/tools/cc-sdd/templates/agents/opencode/commands/validate-gap.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/validate-gap.md
@@ -1,0 +1,51 @@
+---
+description: Analyze implementation gap between requirements and existing codebase
+---
+
+# Implementation Gap Validation
+
+## Parse Arguments
+- Feature name: `$1`
+
+## Validate
+Check that requirements have been completed:
+- Verify `{{KIRO_DIR}}/specs/$1/` exists
+- Verify `{{KIRO_DIR}}/specs/$1/requirements.md` exists
+
+If validation fails, inform user to complete requirements phase first.
+
+## Invoke Subagent
+
+Delegate gap analysis to validate-gap-agent:
+
+Use the Task tool to invoke the Subagent with file path patterns:
+
+```
+Task(
+  subagent_type="validate-gap-agent",
+  description="Analyze implementation gap",
+  prompt="""
+Feature: $1
+Spec directory: {{KIRO_DIR}}/specs/$1/
+
+File patterns to read:
+- {{KIRO_DIR}}/specs/$1/spec.json
+- {{KIRO_DIR}}/specs/$1/requirements.md
+- {{KIRO_DIR}}/steering/*.md
+- {{KIRO_DIR}}/settings/rules/gap-analysis.md
+"""
+)
+```
+
+## Display Result
+
+Show Subagent summary to user, then provide next step guidance:
+
+### Next Phase: Design Generation
+
+**If Gap Analysis Complete**:
+- Review gap analysis insights
+- Run `/kiro/spec-design $1` to create technical design document
+- Or `/kiro/spec-design $1 -y` to auto-approve requirements and proceed directly
+
+**Note**: Gap analysis is optional but recommended for brownfield projects to inform design decisions.

--- a/tools/cc-sdd/templates/agents/opencode/commands/validate-impl.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/validate-impl.md
@@ -1,0 +1,66 @@
+---
+description: Validate implementation against requirements, design, and tasks
+---
+
+# Implementation Validation
+
+## Parse Arguments
+- Feature name: `$1` (optional)
+- Task numbers: `$2` (optional)
+
+## Auto-Detection Logic
+
+**Perform detection before invoking Subagent**:
+
+**If no arguments** (`$1` empty):
+- Parse conversation history for `/kiro/spec-impl <feature> [tasks]` patterns
+- OR scan `{{KIRO_DIR}}/specs/*/tasks.md` for `[x]` checkboxes
+- Pass detected features and tasks to Subagent
+
+**If feature only** (`$1` present, `$2` empty):
+- Read `{{KIRO_DIR}}/specs/$1/tasks.md` and find all `[x]` checkboxes
+- Pass feature and detected tasks to Subagent
+
+**If both provided** (`$1` and `$2` present):
+- Pass directly to Subagent without detection
+
+## Invoke Subagent
+
+Delegate validation to validate-impl-agent:
+
+Use the Task tool to invoke the Subagent with file path patterns:
+
+```
+Task(
+  subagent_type="validate-impl-agent",
+  description="Validate implementation",
+  prompt="""
+Feature: {$1 or auto-detected}
+Target tasks: {$2 or auto-detected}
+Mode: {auto-detect, feature-all, or explicit}
+
+File patterns to read:
+- {{KIRO_DIR}}/specs/{feature}/*.{json,md}
+- {{KIRO_DIR}}/steering/*.md
+
+Validation scope: {based on detection results}
+"""
+)
+```
+
+## Display Result
+
+Show Subagent summary to user, then provide next step guidance:
+
+### Next Steps Guidance
+
+**If GO Decision**:
+- Implementation validated and ready
+- Proceed to deployment or next feature
+
+**If NO-GO Decision**:
+- Address critical issues listed
+- Re-run `/kiro/spec-impl <feature> [tasks]` for fixes
+- Re-validate with `/kiro/validate-impl [feature] [tasks]`
+
+**Note**: Validation is recommended after implementation to ensure spec alignment and quality.

--- a/tools/cc-sdd/templates/agents/opencode/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/opencode/docs/AGENTS.md
@@ -1,0 +1,45 @@
+# AI-DLC and Spec-Driven Development
+
+Kiro-style Spec Driven Development implementation on AI-DLC (AI Development Life Cycle)
+
+## Project Context
+
+### Paths
+- Steering: `{{KIRO_DIR}}/steering/`
+- Specs: `{{KIRO_DIR}}/specs/`
+
+### Steering vs Specification
+
+**Steering** (`{{KIRO_DIR}}/steering/`) - Guide AI with project-wide rules and context
+**Specs** (`{{KIRO_DIR}}/specs/`) - Formalize development process for individual features
+
+### Active Specifications
+- Check `{{KIRO_DIR}}/specs/` for active specifications
+- Use `/kiro/spec-status [feature-name]` to check progress
+
+## Development Guidelines
+{{DEV_GUIDELINES}}
+
+## Minimal Workflow
+- Phase 0 (optional): `/kiro/steering`, `/kiro/steering-custom`
+- Phase 1 (Specification):
+  - `/kiro/spec-init "description"`
+  - `/kiro/spec-requirements {feature}`
+  - `/kiro/validate-gap {feature}` (optional: for existing codebase)
+  - `/kiro/spec-design {feature} [-y]`
+  - `/kiro/validate-design {feature}` (optional: design review)
+  - `/kiro/spec-tasks {feature} [-y]`
+- Phase 2 (Implementation): `/kiro/spec-impl {feature} [tasks]`
+  - `/kiro/validate-impl {feature}` (optional: after implementation)
+- Progress check: `/kiro/spec-status {feature}` (use anytime)
+
+## Development Rules
+- 3-phase approval workflow: Requirements → Design → Tasks → Implementation
+- Human review required each phase; use `-y` only for intentional fast-track
+- Keep steering current and verify alignment with `/kiro/spec-status`
+- Follow the user's instructions precisely, and within that scope act autonomously: gather the necessary context and complete the requested work end-to-end in this run, asking questions only when essential information is missing or the instructions are critically ambiguous.
+
+## Steering Configuration
+- Load entire `{{KIRO_DIR}}/steering/` as project memory
+- Default files: `product.md`, `tech.md`, `structure.md`
+- Custom files are supported (managed via `/kiro/steering-custom`)

--- a/tools/cc-sdd/templates/manifests/opencode.json
+++ b/tools/cc-sdd/templates/manifests/opencode.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "artifacts": [
+    {
+      "id": "commands",
+      "source": {
+        "type": "templateDir",
+        "fromDir": "templates/agents/{{AGENT}}/commands",
+        "toDir": "{{AGENT_COMMANDS_DIR}}"
+      },
+      "when": { "agent": "opencode" }
+    },
+    {
+      "id": "doc_main",
+      "source": {
+        "type": "templateFile",
+        "from": "templates/agents/{{AGENT}}/docs/AGENTS.md",
+        "toDir": ".",
+        "rename": "{{AGENT_DOC}}"
+      },
+      "when": { "agent": "opencode" }
+    },
+    {
+      "id": "agents_library",
+      "source": {
+        "type": "templateDir",
+        "fromDir": "templates/agents/{{AGENT}}/agents",
+        "toDir": "{{AGENT_DIR}}/agent/kiro"
+      },
+      "when": { "agent": "opencode" }
+    },
+    {
+      "id": "settings_common",
+      "source": {
+        "type": "templateDir",
+        "fromDir": "templates/shared/settings",
+        "toDir": "{{KIRO_DIR}}/settings"
+      },
+      "when": { "agent": "opencode" }
+    }
+  ]
+}

--- a/tools/cc-sdd/test/realManifestOpencode.test.ts
+++ b/tools/cc-sdd/test/realManifestOpencode.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { runCli } from '../src/index';
+import { mkdtemp, readFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const runtime = { platform: 'darwin' } as const;
+
+const makeIO = () => {
+  const logs: string[] = [];
+  const errs: string[] = [];
+  return {
+    io: {
+      log: (m: string) => logs.push(m),
+      error: (m: string) => errs.push(m),
+      exit: (_c: number) => {},
+    },
+    get logs() {
+      return logs;
+    },
+    get errs() {
+      return errs;
+    },
+  };
+};
+
+const mkTmp = async () => mkdtemp(join(tmpdir(), 'ccsdd-real-manifest-opencode-'));
+const exists = async (p: string) => { try { await stat(p); return true; } catch { return false; } };
+
+// vitest runs in tools/cc-sdd; repoRoot is two levels up
+const repoRoot = join(process.cwd(), '..', '..');
+const manifestPath = join(repoRoot, 'tools/cc-sdd/templates/manifests/opencode.json');
+
+describe('real opencode manifest', () => {
+  it('dry-run prints plan for opencode.json with placeholders applied', async () => {
+    const ctx = makeIO();
+    const code = await runCli(['--dry-run', '--lang', 'en', '--manifest', manifestPath, '--opencode'], runtime, ctx.io, {});
+    expect(code).toBe(0);
+    const out = ctx.logs.join('\n');
+    expect(out).toMatch(/Plan \(dry-run\)/);
+    expect(out).toContain('[templateDir] commands: templates/agents/opencode/commands -> .opencode/command/kiro');
+    expect(out).toContain('[templateDir] agents_library: templates/agents/opencode/agents -> .opencode/agent/kiro');
+    expect(out).toContain('[templateFile] doc_main: templates/agents/opencode/docs/AGENTS.md -> ./AGENTS.md');
+    expect(out).toContain('[templateDir] settings_common: templates/shared/settings -> .kiro/settings');
+  });
+
+  it('apply writes AGENTS.md, command files, and agent library docs to cwd', async () => {
+    const cwd = await mkTmp();
+    const ctx = makeIO();
+    const code = await runCli(['--lang', 'en', '--manifest', manifestPath, '--overwrite=force', '--opencode'], runtime, ctx.io, {}, { cwd, templatesRoot: process.cwd() });
+    expect(code).toBe(0);
+
+    const doc = join(cwd, 'AGENTS.md');
+    expect(await exists(doc)).toBe(true);
+    const text = await readFile(doc, 'utf8');
+    expect(text).toMatch(/# AI-DLC and Spec-Driven Development/);
+
+    const cmd = join(cwd, '.opencode/command/kiro/spec-init.md');
+    expect(await exists(cmd)).toBe(true);
+
+    const agentSpecImpl = join(cwd, '.opencode/agent/kiro/spec-impl.md');
+    expect(await exists(agentSpecImpl)).toBe(true);
+    const agentSpecImplText = await readFile(agentSpecImpl, 'utf8');
+    expect(agentSpecImplText).toMatch(/mode: subagent/);
+
+    const settingsRule = join(cwd, '.kiro/settings/rules/design-principles.md');
+    expect(await exists(settingsRule)).toBe(true);
+
+    expect(ctx.logs.join('\n')).toMatch(/Setup completed: written=\d+, skipped=\d+/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add OpenCode agent with kiro command templates
- Use `/kiro/` separator format (consistent with cursor agent)

## Why
- Enable spec-driven development workflow for OpenCode users
- OpenCode uses slash separator format for commands (e.g., `/kiro/spec-quick`)

## Impact
- New agent: `--opencode` flag available
- Templates installed to `.opencode/command/kiro/` and `.opencode/agent/kiro/`
- No changes to existing agents