### PR TITLE
Remove think keywords and fix opencode-agent command format

### DIFF
--- a/tools/cc-sdd/templates/agents/claude-code-agent/agents/spec-requirements.md
+++ b/tools/cc-sdd/templates/agents/claude-code-agent/agents/spec-requirements.md
@@ -99,4 +99,3 @@ Provide output in the language specified in spec.json with:
 - **Non-numeric Requirement Headings**: If existing headings do not include a leading numeric ID (for example, they use "Requirement A"), normalize them to numeric IDs and keep that mapping consistent (never mix numeric and alphabetic labels).
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think deeply

--- a/tools/cc-sdd/templates/agents/claude-code-agent/agents/spec-tasks.md
+++ b/tools/cc-sdd/templates/agents/claude-code-agent/agents/spec-tasks.md
@@ -138,4 +138,3 @@ Provide brief summary in the language specified in spec.json:
   - **Stop Execution**: All requirements in requirements.md MUST have numeric IDs. If any requirement lacks a numeric ID, stop and request that requirements.md be fixed before generating tasks.
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think deeply

--- a/tools/cc-sdd/templates/agents/claude-code-agent/agents/steering-custom.md
+++ b/tools/cc-sdd/templates/agents/claude-code-agent/agents/steering-custom.md
@@ -144,4 +144,3 @@ Review and customize as needed.
 - Light references to `{{KIRO_DIR}}/specs/` and `{{KIRO_DIR}}/steering/` are acceptable; avoid other `.kiro/` directories
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think deeply

--- a/tools/cc-sdd/templates/agents/claude-code-agent/agents/steering.md
+++ b/tools/cc-sdd/templates/agents/claude-code-agent/agents/steering.md
@@ -160,4 +160,3 @@ Review and approve as Source of Truth.
 - `{{KIRO_DIR}}/settings/` content should NOT be documented in steering files (settings are metadata, not project knowledge)
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think deeply

--- a/tools/cc-sdd/templates/agents/claude-code-agent/agents/validate-design.md
+++ b/tools/cc-sdd/templates/agents/claude-code-agent/agents/validate-design.md
@@ -95,4 +95,3 @@ Provide output in the language specified in spec.json with:
 - **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think hard

--- a/tools/cc-sdd/templates/agents/claude-code-agent/agents/validate-gap.md
+++ b/tools/cc-sdd/templates/agents/claude-code-agent/agents/validate-gap.md
@@ -96,4 +96,3 @@ Provide output in the language specified in spec.json with:
 - **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think hard

--- a/tools/cc-sdd/templates/agents/claude-code-agent/agents/validate-impl.md
+++ b/tools/cc-sdd/templates/agents/claude-code-agent/agents/validate-impl.md
@@ -143,4 +143,3 @@ Provide output in the language specified in spec.json with:
 - **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think hard

--- a/tools/cc-sdd/templates/agents/claude-code/commands/spec-design.md
+++ b/tools/cc-sdd/templates/agents/claude-code/commands/spec-design.md
@@ -175,5 +175,3 @@ Provide brief summary in the language specified in spec.json:
 - Existing design used as reference (merge mode)
 
 **Note**: Design approval is mandatory before proceeding to task generation.
-
-think hard

--- a/tools/cc-sdd/templates/agents/opencode-agent/agents/spec-requirements.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/agents/spec-requirements.md
@@ -96,4 +96,3 @@ Provide output in the language specified in spec.json with:
 - **Non-numeric Requirement Headings**: If existing headings do not include a leading numeric ID (for example, they use "Requirement A"), normalize them to numeric IDs and keep that mapping consistent (never mix numeric and alphabetic labels).
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think deeply

--- a/tools/cc-sdd/templates/agents/opencode-agent/agents/spec-tasks.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/agents/spec-tasks.md
@@ -135,4 +135,3 @@ Provide brief summary in the language specified in spec.json:
   - **Stop Execution**: All requirements in requirements.md MUST have numeric IDs. If any requirement lacks a numeric ID, stop and request that requirements.md be fixed before generating tasks.
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think deeply

--- a/tools/cc-sdd/templates/agents/opencode-agent/agents/steering-custom.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/agents/steering-custom.md
@@ -141,4 +141,3 @@ Review and customize as needed.
 - Light references to `{{KIRO_DIR}}/specs/` and `{{KIRO_DIR}}/steering/` are acceptable; avoid other `.kiro/` directories
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think deeply

--- a/tools/cc-sdd/templates/agents/opencode-agent/agents/steering.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/agents/steering.md
@@ -157,4 +157,3 @@ Review and approve as Source of Truth.
 - `{{KIRO_DIR}}/settings/` content should NOT be documented in steering files (settings are metadata, not project knowledge)
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think deeply

--- a/tools/cc-sdd/templates/agents/opencode-agent/agents/validate-design.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/agents/validate-design.md
@@ -92,4 +92,3 @@ Provide output in the language specified in spec.json with:
 - **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think hard

--- a/tools/cc-sdd/templates/agents/opencode-agent/agents/validate-gap.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/agents/validate-gap.md
@@ -93,4 +93,3 @@ Provide output in the language specified in spec.json with:
 - **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think hard

--- a/tools/cc-sdd/templates/agents/opencode-agent/agents/validate-impl.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/agents/validate-impl.md
@@ -140,4 +140,3 @@ Provide output in the language specified in spec.json with:
 - **Language Undefined**: Default to English (`en`) if spec.json doesn't specify language
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think hard

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-design.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-design.md
@@ -1,5 +1,7 @@
 ---
 description: Create comprehensive technical design for a specification
+agent: spec-design
+subtask: true
 ---
 
 # Technical Design Generator
@@ -15,17 +17,8 @@ Check that requirements have been completed:
 
 If validation fails, inform user to complete requirements phase first.
 
-## Invoke Subagent
+## Subagent Context
 
-Delegate design generation to spec-design-agent:
-
-Use the Task tool to invoke the Subagent with file path patterns:
-
-```
-Task(
-  subagent_type="spec-design-agent",
-  description="Generate technical design and update research log",
-  prompt="""
 Feature: $1
 Spec directory: {{KIRO_DIR}}/specs/$1/
 Auto-approve: {true if $2 == "-y", else false}
@@ -40,9 +33,6 @@ File patterns to read:
 Discovery: auto-detect based on requirements
 Mode: {generate or merge based on design.md existence}
 Language: respect spec.json language for design.md/research.md outputs
-"""
-)
-```
 
 ## Display Result
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-impl.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-impl.md
@@ -1,5 +1,7 @@
 ---
 description: Execute spec tasks using TDD methodology
+agent: spec-impl
+subtask: true
 ---
 
 # Implementation Task Executor
@@ -23,17 +25,8 @@ If validation fails, inform user to complete tasks generation first.
 - If `$2` provided: Parse task numbers (e.g., "1.1", "1,2,3")
 - Otherwise: Read `{{KIRO_DIR}}/specs/$1/tasks.md` and find all unchecked tasks (`- [ ]`)
 
-## Invoke Subagent
+## Subagent Context
 
-Delegate TDD implementation to spec-tdd-impl-agent:
-
-Use the Task tool to invoke the Subagent with file path patterns:
-
-```
-Task(
-  subagent_type="spec-tdd-impl-agent",
-  description="Execute TDD implementation",
-  prompt="""
 Feature: $1
 Spec directory: {{KIRO_DIR}}/specs/$1/
 Target tasks: {parsed task numbers or "all pending"}
@@ -43,9 +36,6 @@ File patterns to read:
 - {{KIRO_DIR}}/steering/*.md
 
 TDD Mode: strict (test-first)
-"""
-)
-```
 
 ## Display Result
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-requirements.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-requirements.md
@@ -1,5 +1,7 @@
 ---
 description: Generate comprehensive requirements for a specification
+agent: spec-requirements
+subtask: true
 ---
 
 # Requirements Generation
@@ -14,17 +16,8 @@ Check that spec has been initialized:
 
 If validation fails, inform user to run `/kiro-spec-init` first.
 
-## Invoke Subagent
+## Subagent Context
 
-Delegate requirements generation to spec-requirements-agent:
-
-Use the Task tool to invoke the Subagent with file path patterns:
-
-```
-Task(
-  subagent_type="spec-requirements-agent",
-  description="Generate EARS requirements",
-  prompt="""
 Feature: $1
 Spec directory: {{KIRO_DIR}}/specs/$1/
 
@@ -36,9 +29,6 @@ File patterns to read:
 - {{KIRO_DIR}}/settings/templates/specs/requirements.md
 
 Mode: generate
-"""
-)
-```
 
 ## Display Result
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-tasks.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-tasks.md
@@ -1,5 +1,7 @@
 ---
 description: Generate implementation tasks for a specification
+agent: spec-tasks
+subtask: true
 ---
 
 # Implementation Tasks Generator
@@ -17,17 +19,8 @@ Check that design has been completed:
 
 If validation fails, inform user to complete design phase first.
 
-## Invoke Subagent
+## Subagent Context
 
-Delegate task generation to spec-tasks-agent:
-
-Use the Task tool to invoke the Subagent with file path patterns:
-
-```
-Task(
-  subagent_type="spec-tasks-agent",
-  description="Generate implementation tasks",
-  prompt="""
 Feature: $1
 Spec directory: {{KIRO_DIR}}/specs/$1/
 Auto-approve: {true if $2 == "-y", else false}
@@ -46,9 +39,6 @@ Instruction highlights:
 - Promote single actionable sub-tasks to major tasks and keep container summaries concise
 - Apply `(P)` markers only when parallel criteria met (omit in sequential mode)
 - Mark optional acceptance-criteria-focused test coverage subtasks with `- [ ]*` only when deferrable post-MVP
-"""
-)
-```
 
 ## Display Result
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-steering-custom.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-steering-custom.md
@@ -1,5 +1,7 @@
 ---
 description: Create custom steering documents for specialized project contexts
+agent: steering-custom
+subtask: true
 ---
 
 # Kiro Custom Steering Creation
@@ -12,17 +14,8 @@ This command starts an interactive process with the Subagent:
 3. Subagent analyzes codebase for relevant patterns
 4. Subagent generates custom steering file
 
-## Invoke Subagent
+## Subagent Context
 
-Delegate custom steering creation to steering-custom-agent:
-
-Use the Task tool to invoke the Subagent with file path patterns:
-
-```
-Task(
-  subagent_type="steering-custom-agent",
-  description="Create custom steering",
-  prompt="""
 Interactive Mode: Ask user for domain/topic
 
 File patterns to read:
@@ -30,9 +23,6 @@ File patterns to read:
 - {{KIRO_DIR}}/settings/rules/steering-principles.md
 
 JIT Strategy: Analyze codebase for relevant patterns as needed
-"""
-)
-```
 
 ## Display Result
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-steering.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-steering.md
@@ -1,5 +1,7 @@
 ---
 description: Manage {{KIRO_DIR}}/steering/ as persistent project knowledge
+agent: steering
+subtask: true
 ---
 
 # Kiro Steering Management
@@ -14,17 +16,8 @@ Check `{{KIRO_DIR}}/steering/` status:
 
 Use Glob to check for existing steering files.
 
-## Invoke Subagent
+## Subagent Context
 
-Delegate steering management to steering-agent:
-
-Use the Task tool to invoke the Subagent with file path patterns:
-
-```
-Task(
-  subagent_type="steering-agent",
-  description="Manage steering files",
-  prompt="""
 Mode: {bootstrap or sync based on detection}
 
 File patterns to read:
@@ -33,9 +26,6 @@ File patterns to read:
 - {{KIRO_DIR}}/settings/rules/steering-principles.md
 
 JIT Strategy: Fetch codebase files when needed, not upfront
-"""
-)
-```
 
 ## Display Result
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-validate-design.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-validate-design.md
@@ -1,5 +1,7 @@
 ---
 description: Interactive technical design quality review and validation
+agent: validate-design
+subtask: true
 ---
 
 # Technical Design Validation
@@ -14,17 +16,8 @@ Check that design has been completed:
 
 If validation fails, inform user to complete design phase first.
 
-## Invoke Subagent
+## Subagent Context
 
-Delegate design validation to validate-design-agent:
-
-Use the Task tool to invoke the Subagent with file path patterns:
-
-```
-Task(
-  subagent_type="validate-design-agent",
-  description="Interactive design review",
-  prompt="""
 Feature: $1
 Spec directory: {{KIRO_DIR}}/specs/$1/
 
@@ -34,9 +27,6 @@ File patterns to read:
 - {{KIRO_DIR}}/specs/$1/design.md
 - {{KIRO_DIR}}/steering/*.md
 - {{KIRO_DIR}}/settings/rules/design-review.md
-"""
-)
-```
 
 ## Display Result
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-validate-gap.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-validate-gap.md
@@ -1,5 +1,7 @@
 ---
 description: Analyze implementation gap between requirements and existing codebase
+agent: validate-gap
+subtask: true
 ---
 
 # Implementation Gap Validation
@@ -14,17 +16,8 @@ Check that requirements have been completed:
 
 If validation fails, inform user to complete requirements phase first.
 
-## Invoke Subagent
+## Subagent Context
 
-Delegate gap analysis to validate-gap-agent:
-
-Use the Task tool to invoke the Subagent with file path patterns:
-
-```
-Task(
-  subagent_type="validate-gap-agent",
-  description="Analyze implementation gap",
-  prompt="""
 Feature: $1
 Spec directory: {{KIRO_DIR}}/specs/$1/
 
@@ -33,9 +26,6 @@ File patterns to read:
 - {{KIRO_DIR}}/specs/$1/requirements.md
 - {{KIRO_DIR}}/steering/*.md
 - {{KIRO_DIR}}/settings/rules/gap-analysis.md
-"""
-)
-```
 
 ## Display Result
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-validate-impl.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-validate-impl.md
@@ -1,5 +1,7 @@
 ---
 description: Validate implementation against requirements, design, and tasks
+agent: validate-impl
+subtask: true
 ---
 
 # Implementation Validation
@@ -24,17 +26,8 @@ description: Validate implementation against requirements, design, and tasks
 **If both provided** (`$1` and `$2` present):
 - Pass directly to Subagent without detection
 
-## Invoke Subagent
+## Subagent Context
 
-Delegate validation to validate-impl-agent:
-
-Use the Task tool to invoke the Subagent with file path patterns:
-
-```
-Task(
-  subagent_type="validate-impl-agent",
-  description="Validate implementation",
-  prompt="""
 Feature: {$1 or auto-detected}
 Target tasks: {$2 or auto-detected}
 Mode: {auto-detect, feature-all, or explicit}
@@ -44,9 +37,6 @@ File patterns to read:
 - {{KIRO_DIR}}/steering/*.md
 
 Validation scope: {based on detection results}
-"""
-)
-```
 
 ## Display Result
 

--- a/tools/cc-sdd/templates/agents/opencode/commands/kiro-spec-design.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/kiro-spec-design.md
@@ -174,5 +174,3 @@ Provide brief summary in the language specified in spec.json:
 - Existing design used as reference (merge mode)
 
 **Note**: Design approval is mandatory before proceeding to task generation.
-
-think hard


### PR DESCRIPTION
## Summary
- Remove `think hard` / `think deeply` keywords from 16 template files
- Convert opencode-agent commands from Task() syntax to OpenCode format

## Why
- Think keywords no longer have meaning in Claude Code
- OpenCode-agent was using Claude Code Task() syntax which doesn't work in OpenCode

## Impact
- Affected agents: claude-code, opencode, claude-code-agent, opencode-agent
- No impact on: gemini-cli, cursor, qwen-code, windsurf, codex, github-copilot
- OpenCode-agent commands now use proper frontmatter with `agent:` and `subtask: true`

🤖 Generated with [Claude Code](https://claude.ai/code)