### PR TITLE
Update recommended models to Opus 4.5 and GPT-5.2

### DIFF
--- a/tools/cc-sdd/src/agents/registry.ts
+++ b/tools/cc-sdd/src/agents/registry.ts
@@ -41,7 +41,7 @@ export const agentDefinitions = {
     description:
       'Installs kiro prompts in `.claude/commands/kiro/`, shared settings in `{{KIRO_DIR}}/settings/` (default `.kiro/settings/`), and an AGENTS.md quickstart.',
     aliasFlags: ['--claude-code', '--claude'],
-    recommendedModels: ['Claude 4.5 Sonnet or newer'],
+    recommendedModels: ['Claude Opus 4.5 or newer'],
     layout: {
       commandsDir: '.claude/commands/kiro',
       agentDir: '.claude',
@@ -62,7 +62,7 @@ export const agentDefinitions = {
     description:
       'Installs kiro prompts in `.claude/commands/kiro/`, a Claude agent library in `.claude/agents/kiro/`, shared settings in `{{KIRO_DIR}}/settings/`, and a CLAUDE.md quickstart.',
     aliasFlags: ['--claude-code-agent', '--claude-agent'],
-    recommendedModels: ['Claude 4.5 Sonnet or newer'],
+    recommendedModels: ['Claude Opus 4.5 or newer'],
     layout: {
       commandsDir: '.claude/commands/kiro',
       agentDir: '.claude',
@@ -83,7 +83,7 @@ export const agentDefinitions = {
     description:
       'Installs kiro prompts in `.codex/prompts/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--codex', '--codex-cli'],
-    recommendedModels: ['gpt-5.1-codex medium/high', 'gpt-5.1 medium/high'],
+    recommendedModels: ['gpt-5.2-codex', 'gpt-5.2'],
     layout: {
       commandsDir: '.codex/prompts',
       agentDir: '.codex',
@@ -104,11 +104,7 @@ export const agentDefinitions = {
     description:
       'Installs kiro prompts in `.cursor/commands/kiro/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--cursor'],
-    recommendedModels: [
-      'Claude 4.5 Sonnet thinking mode or newer',
-      'gpt-5.1-codex medium/high',
-      'gpt-5.1 medium/high',
-    ],
+    recommendedModels: ['Claude Opus 4.5 or newer', 'gpt-5.2-codex', 'gpt-5.2'],
     layout: {
       commandsDir: '.cursor/commands/kiro',
       agentDir: '.cursor',
@@ -126,11 +122,7 @@ export const agentDefinitions = {
     description:
       'Installs kiro prompts in `.github/prompts/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--copilot', '--github-copilot'],
-    recommendedModels: [
-      'Claude 4.5 Sonnet thinking mode or newer',
-      'gpt-5.1-codex medium/high',
-      'gpt-5.1 medium/high',
-    ],
+    recommendedModels: ['Claude Opus 4.5 or newer', 'gpt-5.2-codex', 'gpt-5.2'],
     layout: {
       commandsDir: '.github/prompts',
       agentDir: '.github',
@@ -166,7 +158,7 @@ export const agentDefinitions = {
     description:
       'Installs kiro workflows in `.windsurf/workflows/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--windsurf'],
-    recommendedModels: ['Claude 4.5 Sonnet or newer', 'gpt-5.1-codex medium/high', 'gpt-5.1 medium/high'],
+    recommendedModels: ['Claude Opus 4.5 or newer', 'gpt-5.2-codex', 'gpt-5.2'],
     layout: {
       commandsDir: '.windsurf/workflows',
       agentDir: '.windsurf',
@@ -201,6 +193,7 @@ export const agentDefinitions = {
     description:
       'Installs kiro prompts in `.opencode/commands/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--opencode'],
+    recommendedModels: ['gpt-5.2-codex', 'gpt-5.2'],
     layout: {
       commandsDir: '.opencode/commands',
       agentDir: '.opencode',
@@ -218,6 +211,7 @@ export const agentDefinitions = {
     description:
       'Installs kiro commands in `.opencode/commands/`, a kiro agent library in `.opencode/agents/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--opencode-agent'],
+    recommendedModels: ['gpt-5.2-codex', 'gpt-5.2'],
     layout: {
       commandsDir: '.opencode/commands',
       agentDir: '.opencode',

--- a/tools/cc-sdd/test/realManifestCursor.test.ts
+++ b/tools/cc-sdd/test/realManifestCursor.test.ts
@@ -72,9 +72,9 @@ describe('real cursor manifest', () => {
     
     // Check that the Cursor-specific recommended models are shown
     expect(out).toContain('Recommended models');
-    expect(out).toContain('Claude 4.5 Sonnet');
-    expect(out).toContain('gpt-5.1-codex medium/high');
-    expect(out).toContain('gpt-5.1 medium/high');
+    expect(out).toContain('Claude Opus 4.5');
+    expect(out).toContain('gpt-5.2-codex');
+    expect(out).toContain('gpt-5.2');
 
     // Check that the unified next steps are present
     expect(out).toContain("Launch Cursor IDE and run `/kiro/spec-init <what-to-build>` to create a new specification.");

--- a/tools/cc-sdd/test/realManifestWindsurf.test.ts
+++ b/tools/cc-sdd/test/realManifestWindsurf.test.ts
@@ -67,9 +67,9 @@ describe('real windsurf manifest', () => {
 
     expect(out).toMatch(/Setup completed: written=\d+, skipped=\d+/);
     expect(out).toContain('Recommended models');
-    expect(out).toContain('Claude 4.5 Sonnet');
-    expect(out).toContain('gpt-5.1-codex medium/high');
-    expect(out).toContain('gpt-5.1 medium/high');
+    expect(out).toContain('Claude Opus 4.5');
+    expect(out).toContain('gpt-5.2-codex');
+    expect(out).toContain('gpt-5.2');
     expect(out).toContain('Launch Windsurf IDE and run `/kiro-spec-init <what-to-build>` to create a new specification.');
     expect(out).toMatch(
       /Tip: Steering holds persistent project knowledge—patterns, standards, and org-wide policies\. Kick off `\/kiro-steering` \(essential for existing projects\) and\s+`\/kiro-steering-custom <what-to-create-custom-steering-document>`\. Maintain Regularly/,


### PR DESCRIPTION
## Summary
- Update Claude recommendations from Sonnet to Opus 4.5
- Update GPT recommendations from 5.1 to 5.2
- Add missing recommendedModels for opencode and opencode-agent

## Why
- Opus 4.5 and GPT-5.2 are now the recommended frontier models
- opencode/opencode-agent were missing model recommendations

## Impact
- All agents now have up-to-date model recommendations
- No breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)