### PR TITLE
Remove standalone think keywords from templates

### DIFF
--- a/tools/cc-sdd/templates/agents/claude-code-agent/agents/spec-design.md
+++ b/tools/cc-sdd/templates/agents/claude-code-agent/agents/spec-design.md
@@ -171,4 +171,3 @@ Provide brief summary in the language specified in spec.json:
   - **Stop Execution**: If requirements.md is missing numeric IDs or uses non-numeric headings (for example, "Requirement A"), stop and instruct the user to fix requirements.md before continuing.
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think

--- a/tools/cc-sdd/templates/agents/claude-code-agent/agents/spec-impl.md
+++ b/tools/cc-sdd/templates/agents/claude-code-agent/agents/spec-impl.md
@@ -118,4 +118,3 @@ Provide brief summary in the language specified in spec.json:
 - **Action**: Debug and fix, then re-run
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think

--- a/tools/cc-sdd/templates/agents/claude-code-agent/commands/spec-status.md
+++ b/tools/cc-sdd/templates/agents/claude-code-agent/commands/spec-status.md
@@ -83,5 +83,3 @@ Provide status report in the language specified in spec.json:
 To see all available specs:
 - Run with no argument or use wildcard
 - Shows all specs in `{{KIRO_DIR}}/specs/` with their status
-
-think

--- a/tools/cc-sdd/templates/agents/claude-code/commands/spec-impl.md
+++ b/tools/cc-sdd/templates/agents/claude-code/commands/spec-impl.md
@@ -106,5 +106,3 @@ Provide brief summary in the language specified in spec.json:
 
 **Execute all pending**:
 - `/kiro:spec-impl $1` - All unchecked tasks
-
-think

--- a/tools/cc-sdd/templates/agents/claude-code/commands/spec-requirements.md
+++ b/tools/cc-sdd/templates/agents/claude-code/commands/spec-requirements.md
@@ -94,5 +94,3 @@ Provide output in the language specified in spec.json with:
 - Provide feedback and re-run `/kiro:spec-requirements $1`
 
 **Note**: Approval is mandatory before proceeding to design phase.
-
-think

--- a/tools/cc-sdd/templates/agents/claude-code/commands/spec-status.md
+++ b/tools/cc-sdd/templates/agents/claude-code/commands/spec-status.md
@@ -83,5 +83,3 @@ Provide status report in the language specified in spec.json:
 To see all available specs:
 - Run with no argument or use wildcard
 - Shows all specs in `{{KIRO_DIR}}/specs/` with their status
-
-think

--- a/tools/cc-sdd/templates/agents/claude-code/commands/spec-tasks.md
+++ b/tools/cc-sdd/templates/agents/claude-code/commands/spec-tasks.md
@@ -134,5 +134,3 @@ Provide brief summary in the language specified in spec.json:
 - Existing tasks used as reference (merge mode)
 
 **Note**: The implementation phase will guide you through executing tasks with appropriate context and validation.
-
-think

--- a/tools/cc-sdd/templates/agents/opencode-agent/agents/spec-design.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/agents/spec-design.md
@@ -168,4 +168,3 @@ Provide brief summary in the language specified in spec.json:
   - **Stop Execution**: If requirements.md is missing numeric IDs or uses non-numeric headings (for example, "Requirement A"), stop and instruct the user to fix requirements.md before continuing.
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think

--- a/tools/cc-sdd/templates/agents/opencode-agent/agents/spec-impl.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/agents/spec-impl.md
@@ -115,4 +115,3 @@ Provide brief summary in the language specified in spec.json:
 - **Action**: Debug and fix, then re-run
 
 **Note**: You execute tasks autonomously. Return final report only when complete.
-think

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-status.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-status.md
@@ -81,5 +81,3 @@ Provide status report in the language specified in spec.json:
 To see all available specs:
 - Run with no argument or use wildcard
 - Shows all specs in `{{KIRO_DIR}}/specs/` with their status
-
-think

--- a/tools/cc-sdd/templates/agents/opencode/commands/kiro-spec-impl.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/kiro-spec-impl.md
@@ -105,5 +105,3 @@ Provide brief summary in the language specified in spec.json:
 
 **Execute all pending**:
 - `/kiro-spec-impl $1` - All unchecked tasks
-
-think

--- a/tools/cc-sdd/templates/agents/opencode/commands/kiro-spec-requirements.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/kiro-spec-requirements.md
@@ -93,5 +93,3 @@ Provide output in the language specified in spec.json with:
 - Provide feedback and re-run `/kiro-spec-requirements $1`
 
 **Note**: Approval is mandatory before proceeding to design phase.
-
-think

--- a/tools/cc-sdd/templates/agents/opencode/commands/kiro-spec-status.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/kiro-spec-status.md
@@ -82,5 +82,3 @@ Provide status report in the language specified in spec.json:
 To see all available specs:
 - Run with no argument or use wildcard
 - Shows all specs in `{{KIRO_DIR}}/specs/` with their status
-
-think

--- a/tools/cc-sdd/templates/agents/opencode/commands/kiro-spec-tasks.md
+++ b/tools/cc-sdd/templates/agents/opencode/commands/kiro-spec-tasks.md
@@ -133,5 +133,3 @@ Provide brief summary in the language specified in spec.json:
 - Existing tasks used as reference (merge mode)
 
 **Note**: The implementation phase will guide you through executing tasks with appropriate context and validation.
-
-think


### PR DESCRIPTION
## Summary
- Remove remaining `think` keywords from 14 template files

## Why
- `think` keywords no longer have meaning in Claude Code
- This completes the cleanup started in PR #128

## Impact
- 14 files modified across claude-code, claude-code-agent, opencode, opencode-agent

🤖 Generated with [Claude Code](https://claude.ai/code)