### PR TITLE
Update gemini-cli recommended model to Gemini 3 Flash

### DIFF
--- a/tools/cc-sdd/src/agents/registry.ts
+++ b/tools/cc-sdd/src/agents/registry.ts
@@ -140,7 +140,7 @@ export const agentDefinitions = {
     description:
       'Installs kiro prompts in `.gemini/commands/kiro/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--gemini-cli', '--gemini'],
-    recommendedModels: ['Gemini 2.5 Pro or newer'],
+    recommendedModels: ['Gemini 3 Flash or newer'],
     layout: {
       commandsDir: '.gemini/commands/kiro',
       agentDir: '.gemini',


### PR DESCRIPTION
## Summary
- Update gemini-cli recommendedModels from Gemini 2.5 Pro to Gemini 3 Flash

## Why
- Gemini 3 Flash is the latest recommended model (released Dec 2025)
- Better performance on coding benchmarks (78% SWE-bench Verified)

## Impact
- gemini-cli only

🤖 Generated with [Claude Code](https://claude.ai/code)