### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-02-01
+
+### Added
+- **OpenCode support** - 8th supported agent with full SDD workflow integration ([#117](https://github.com/gotalab/cc-sdd/pull/117), [#127](https://github.com/gotalab/cc-sdd/pull/127))
+  - `.opencode/commands/` with 11 kiro commands
+  - OpenCode Agents (subagent version) in `.opencode/agents/`
+  - OPENCODE.md project memory template
+  - Installation via `npx cc-sdd@latest --opencode` or `--opencode-agent`
+
+### Changed
+- Update recommended models to latest versions ([#128](https://github.com/gotalab/cc-sdd/pull/128), [#129](https://github.com/gotalab/cc-sdd/pull/129))
+  - Claude: Opus 4.5
+  - OpenAI: GPT-5.2
+  - Google: Gemini 3 Flash
+- Remove think keywords from templates for cleaner prompts ([#128](https://github.com/gotalab/cc-sdd/pull/128))
+
+### New Contributors
+* @inovue made their first contribution in #117
+
 ## [2.0.5] - 2026-01-08
 
 ### Added

--- a/docs/RELEASE_NOTES/RELEASE_NOTES_en.md
+++ b/docs/RELEASE_NOTES/RELEASE_NOTES_en.md
@@ -6,7 +6,39 @@ New features and improvements for cc-sdd. See [CHANGELOG.md](../../CHANGELOG.md)
 
 ## 🔬 In Development (Unreleased)
 
-No unreleased features at this time. The latest stable release is v2.0.5.
+No unreleased features at this time. The latest stable release is v2.1.0.
+
+---
+
+## 🚀 Ver 2.1.0 (2026-02-01) – OpenCode Support
+
+### 🎯 Highlights
+- **OpenCode Support**: Added the 8th supported agent with full Spec-Driven Development workflow integration.
+- **Model Updates**: Updated recommended models to Opus 4.5, GPT-5.2, and Gemini 3 Flash for improved performance.
+
+### ✨ Added
+- **OpenCode** ([#117](https://github.com/gotalab/cc-sdd/pull/117), [#127](https://github.com/gotalab/cc-sdd/pull/127))
+  - `.opencode/commands/` with all 11 kiro commands
+  - OpenCode Agents (subagent version) in `.opencode/agents/`
+  - OPENCODE.md project memory template
+  - Installation: `npx cc-sdd@latest --opencode` or `--opencode-agent`
+
+### 🔧 Changed
+- Updated recommended models ([#128](https://github.com/gotalab/cc-sdd/pull/128), [#129](https://github.com/gotalab/cc-sdd/pull/129))
+  - Claude: Opus 4.5
+  - OpenAI: GPT-5.2
+  - Google: Gemini 3 Flash
+- Removed think keywords from templates for cleaner prompts
+
+### 📈 Key Metrics
+- **Supported Agents**: 8 (Claude Code, Cursor, Gemini CLI, Codex CLI, GitHub Copilot, Qwen Code, Windsurf, **OpenCode**)
+- **Commands**: 11 per agent
+- **Languages**: 13
+
+### 🙏 New Contributors
+* @inovue made their first contribution in #117
+
+- Resources: [CHANGELOG.md](../../CHANGELOG.md#210---2026-02-01), PRs: [#117](https://github.com/gotalab/cc-sdd/pull/117), [#127](https://github.com/gotalab/cc-sdd/pull/127), [#128](https://github.com/gotalab/cc-sdd/pull/128), [#129](https://github.com/gotalab/cc-sdd/pull/129)
 
 ---
 

--- a/docs/RELEASE_NOTES/RELEASE_NOTES_ja.md
+++ b/docs/RELEASE_NOTES/RELEASE_NOTES_ja.md
@@ -6,7 +6,39 @@ cc-sddの新機能・改善情報をお届けします。技術的な変更履�
 
 ## 🔬 開発中 (Unreleased)
 
-現在、未リリースの機能はありません。最新の安定版はv2.0.5です。
+現在、未リリースの機能はありません。最新の安定版はv2.1.0です。
+
+---
+
+## 🚀 Ver 2.1.0 (2026-02-01) - OpenCodeサポート
+
+### 🎯 ハイライト
+- **OpenCodeサポート**: 8番目のエージェントとして、完全なSpec-Driven Developmentワークフローを統合。
+- **推奨モデル更新**: Opus 4.5、GPT-5.2、Gemini 3 Flashに更新し、パフォーマンスを向上。
+
+### ✨ 追加
+- **OpenCode** ([#117](https://github.com/gotalab/cc-sdd/pull/117), [#127](https://github.com/gotalab/cc-sdd/pull/127))
+  - `.opencode/commands/` に全11個のkiroコマンド
+  - `.opencode/agents/` にOpenCode Agents（サブエージェント版）
+  - OPENCODE.md プロジェクトメモリテンプレート
+  - インストール: `npx cc-sdd@latest --opencode` または `--opencode-agent`
+
+### 🔧 変更
+- 推奨モデルを更新 ([#128](https://github.com/gotalab/cc-sdd/pull/128), [#129](https://github.com/gotalab/cc-sdd/pull/129))
+  - Claude: Opus 4.5
+  - OpenAI: GPT-5.2
+  - Google: Gemini 3 Flash
+- テンプレートからthinkキーワードを削除し、プロンプトをクリーンに
+
+### 📈 主要メトリクス
+- **対応エージェント**: 8 (Claude Code, Cursor, Gemini CLI, Codex CLI, GitHub Copilot, Qwen Code, Windsurf, **OpenCode**)
+- **コマンド数**: 各エージェント11
+- **対応言語**: 13
+
+### 🙏 新規コントリビューター
+* @inovue が #117 で初コントリビュート
+
+- リソース: [CHANGELOG.md](../../CHANGELOG.md#210---2026-02-01), PR: [#117](https://github.com/gotalab/cc-sdd/pull/117), [#127](https://github.com/gotalab/cc-sdd/pull/127), [#128](https://github.com/gotalab/cc-sdd/pull/128), [#129](https://github.com/gotalab/cc-sdd/pull/129)
 
 ---
 

--- a/tools/cc-sdd/package.json
+++ b/tools/cc-sdd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-sdd",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "Transform your coding workflow with AI-DLC and Spec-Driven Development. One command installs 11 powerful slash commands, Project Memory, and structured development workflows for 8 AI coding agents.",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary
- Add OpenCode Agent support as the 8th supported agent
- Update recommended models to Opus 4.5, GPT-5.2, Gemini 3 Flash
- Remove think keywords from templates for cleaner prompts

## Changes
- `tools/cc-sdd/package.json` - Bump version to 2.1.0
- `CHANGELOG.md` - Add v2.1.0 release entry
- `docs/RELEASE_NOTES/RELEASE_NOTES_en.md` - Add v2.1.0 section
- `docs/RELEASE_NOTES/RELEASE_NOTES_ja.md` - Add v2.1.0 section

## Related PRs
- #117, #127 - OpenCode Agent support
- #128, #129 - Model updates

## Test plan
- [x] Verify version is 2.1.0 in package.json
- [x] Verify CHANGELOG.md has correct v2.1.0 entry
- [x] Verify release notes are updated in both languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)