### PR TITLE
fix(opencode-agent): use full agent path in slash command frontmatter

### DIFF
--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-design.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-design.md
@@ -1,6 +1,6 @@
 ---
 description: Create comprehensive technical design for a specification
-agent: spec-design
+agent: kiro/spec-design
 subtask: true
 ---
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-impl.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-impl.md
@@ -1,6 +1,6 @@
 ---
 description: Execute spec tasks using TDD methodology
-agent: spec-impl
+agent: kiro/spec-impl
 subtask: true
 ---
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-requirements.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-requirements.md
@@ -1,6 +1,6 @@
 ---
 description: Generate comprehensive requirements for a specification
-agent: spec-requirements
+agent: kiro/spec-requirements
 subtask: true
 ---
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-tasks.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-spec-tasks.md
@@ -1,6 +1,6 @@
 ---
 description: Generate implementation tasks for a specification
-agent: spec-tasks
+agent: kiro/spec-tasks
 subtask: true
 ---
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-steering-custom.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-steering-custom.md
@@ -1,6 +1,6 @@
 ---
 description: Create custom steering documents for specialized project contexts
-agent: steering-custom
+agent: kiro/steering-custom
 subtask: true
 ---
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-steering.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-steering.md
@@ -1,6 +1,6 @@
 ---
 description: Manage {{KIRO_DIR}}/steering/ as persistent project knowledge
-agent: steering
+agent: kiro/steering
 subtask: true
 ---
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-validate-design.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-validate-design.md
@@ -1,6 +1,6 @@
 ---
 description: Interactive technical design quality review and validation
-agent: validate-design
+agent: kiro/validate-design
 subtask: true
 ---
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-validate-gap.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-validate-gap.md
@@ -1,6 +1,6 @@
 ---
 description: Analyze implementation gap between requirements and existing codebase
-agent: validate-gap
+agent: kiro/validate-gap
 subtask: true
 ---
 

--- a/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-validate-impl.md
+++ b/tools/cc-sdd/templates/agents/opencode-agent/commands/kiro-validate-impl.md
@@ -1,6 +1,6 @@
 ---
 description: Validate implementation against requirements, design, and tasks
-agent: validate-impl
+agent: kiro/validate-impl
 subtask: true
 ---
 


### PR DESCRIPTION
## 概要

opencode-agent のスラッシュコマンドで `agent:` frontmatter の値が実際の agent path 形式と一致しておらず、subagent が呼び出されない問題を修正しました。

## 変更内容

`agent:` の値に `kiro/` プレフィックスを追加し、OpenCode の Task tool が期待する agent path 形式に合わせました。

| ファイル | 変更前 | 変更後 |
|---------|--------|--------|
| kiro-validate-impl.md | `validate-impl` | `kiro/validate-impl` |
| kiro-validate-gap.md | `validate-gap` | `kiro/validate-gap` |
| kiro-validate-design.md | `validate-design` | `kiro/validate-design` |
| kiro-spec-tasks.md | `spec-tasks` | `kiro/spec-tasks` |
| kiro-steering.md | `steering` | `kiro/steering` |
| kiro-spec-requirements.md | `spec-requirements` | `kiro/spec-requirements` |
| kiro-spec-impl.md | `spec-impl` | `kiro/spec-impl` |
| kiro-spec-design.md | `spec-design` | `kiro/spec-design` |
| kiro-steering-custom.md | `steering-custom` | `kiro/steering-custom` |

## 関連issue

https://github.com/gotalab/cc-sdd/issues/133
