### PR TITLE
Add codex agent skills setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ npx cc-sdd@latest --claude         # Claude Code (11 commands) [default]
 npx cc-sdd@latest --claude-agent   # Claude Code Subagents (12 commands + 9 subagents)
 npx cc-sdd@latest --cursor         # Cursor IDE
 npx cc-sdd@latest --gemini         # Gemini CLI
-npx cc-sdd@latest --codex          # Codex CLI
+npx cc-sdd@latest --codex-skills   # Codex CLI (Skills) [recommended]
+npx cc-sdd@latest --codex          # Codex CLI (deprecated Custom prompts)
 npx cc-sdd@latest --copilot        # GitHub Copilot
 npx cc-sdd@latest --qwen           # Qwen Code
 npx cc-sdd@latest --opencode       # OpenCode (11 commands)

--- a/tools/cc-sdd/README.md
+++ b/tools/cc-sdd/README.md
@@ -43,7 +43,8 @@ npx cc-sdd@latest --claude        # Claude Code (11 commands, en/ja/zh-TW/...)
 npx cc-sdd@latest --claude-agent --lang ja  # Claude Code Subagents (12 commands + 9 subagents)
 npx cc-sdd@latest --cursor --lang zh-TW     # Cursor IDE (choose any supported lang)
 npx cc-sdd@latest --gemini --lang es        # Gemini CLI
-npx cc-sdd@latest --codex --lang fr         # Codex CLI
+npx cc-sdd@latest --codex-skills --lang fr  # Codex CLI (Skills) [recommended]
+npx cc-sdd@latest --codex --lang fr         # Codex CLI (deprecated Custom prompts)
 npx cc-sdd@latest --copilot --lang pt       # GitHub Copilot
 npx cc-sdd@latest --qwen --lang de          # Qwen Code
 npx cc-sdd@latest --opencode --lang en      # OpenCode (11 commands)

--- a/tools/cc-sdd/README_ja.md
+++ b/tools/cc-sdd/README_ja.md
@@ -43,7 +43,8 @@ npx cc-sdd@latest --claude --lang ja        # Claude Code（11コマンド、対
 npx cc-sdd@latest --claude-agent --lang ja  # Claude Code Subagents（12コマンド + 9サブエージェント）
 npx cc-sdd@latest --cursor --lang ja        # Cursor IDE
 npx cc-sdd@latest --gemini --lang ja        # Gemini CLI
-npx cc-sdd@latest --codex --lang ja         # Codex CLI
+npx cc-sdd@latest --codex-skills --lang ja  # Codex CLI（Skills）[推奨]
+npx cc-sdd@latest --codex --lang ja         # Codex CLI（非推奨: Custom prompts）
 npx cc-sdd@latest --copilot --lang ja       # GitHub Copilot
 npx cc-sdd@latest --qwen --lang ja          # Qwen Code
 npx cc-sdd@latest --opencode --lang ja      # OpenCode（11コマンド）

--- a/tools/cc-sdd/README_zh-TW.md
+++ b/tools/cc-sdd/README_zh-TW.md
@@ -40,7 +40,8 @@ npx cc-sdd@latest --claude --lang zh-TW           # Claude Code（11 個指令�
 npx cc-sdd@latest --claude-agent --lang zh-TW     # Claude Code Subagents（12 個指令 + 9 個子代理）
 npx cc-sdd@latest --cursor --lang zh-TW           # Cursor IDE
 npx cc-sdd@latest --gemini --lang zh-TW           # Gemini CLI
-npx cc-sdd@latest --codex --lang zh-TW            # Codex CLI
+npx cc-sdd@latest --codex-skills --lang zh-TW     # Codex CLI (Skills) [recommended]
+npx cc-sdd@latest --codex --lang zh-TW            # Codex CLI (deprecated Custom prompts)
 npx cc-sdd@latest --copilot --lang zh-TW          # GitHub Copilot
 npx cc-sdd@latest --qwen --lang zh-TW             # Qwen Code
 npx cc-sdd@latest --opencode --lang zh-TW         # OpenCode（11 個指令）

--- a/tools/cc-sdd/src/agents/registry.ts
+++ b/tools/cc-sdd/src/agents/registry.ts
@@ -35,6 +35,14 @@ const codexCopyInstruction = String.raw`Move Codex Custom prompts to ~/.codex/pr
       && IFS= read -r a \
       && case "$a" in [yY]) rm -rf ./.codex/prompts && echo 'Removed.' ;; *) echo 'Kept original.' ;; esac`;
 
+const codexSkillsCopyInstruction = String.raw`Move Codex Skills to ~/.codex/skills by running:
+    mkdir -p ~/.codex/skills \
+      && cp -Ri ./.codex/skills/. ~/.codex/skills/ \
+      && printf '\n==== COPY PHASE DONE ====\n' \
+      && printf 'Remove original ./.codex/skills ? [y/N]: ' \
+      && IFS= read -r a \
+      && case "$a" in [yY]) rm -rf ./.codex/skills && echo 'Removed.' ;; *) echo 'Kept original.' ;; esac`;
+
 export const agentDefinitions = {
   'claude-code': {
     label: 'Claude Code',
@@ -81,7 +89,7 @@ export const agentDefinitions = {
   codex: {
     label: 'Codex CLI',
     description:
-      'Installs kiro prompts in `.codex/prompts/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
+      'Installs kiro prompts in `.codex/prompts/` (deprecated Custom prompts mode), shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--codex', '--codex-cli'],
     recommendedModels: ['gpt-5.2-codex', 'gpt-5.2'],
     layout: {
@@ -98,6 +106,28 @@ export const agentDefinitions = {
       prependSteps: [codexCopyInstruction],
     },
     manifestId: 'codex',
+  },
+  'codex-skills': {
+    label: 'Codex CLI (Skills)',
+    description:
+      'Installs kiro Skills in `.codex/skills/` (recommended), shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
+    aliasFlags: ['--codex-skills'],
+    recommendedModels: ['gpt-5.2-codex', 'gpt-5.2'],
+    layout: {
+      commandsDir: '.codex/skills',
+      agentDir: '.codex',
+      docFile: 'AGENTS.md',
+    },
+    commands: {
+      spec: '`$kiro-spec-init <what-to-build>`',
+      steering: '`$kiro-steering`',
+      steeringCustom: '`$kiro-steering-custom <what-to-create-custom-steering-document>`',
+    },
+    completionGuide: {
+      prependSteps: [codexSkillsCopyInstruction],
+      appendSteps: ['In Codex, use `$kiro-*` Skills to run the spec-driven workflow (try `$kiro-spec-init`).'],
+    },
+    manifestId: 'codex-skills',
   },
   cursor: {
     label: 'Cursor IDE',

--- a/tools/cc-sdd/templates/agents/codex-skills/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/docs/AGENTS.md
@@ -1,0 +1,52 @@
+# AI-DLC and Spec-Driven Development
+
+Kiro-style Spec Driven Development implementation on AI-DLC (AI Development Life Cycle)
+
+## Project Memory
+Project memory keeps persistent guidance (steering, specs notes, component docs) so Codex honors your standards each run. Treat it as the long-lived source of truth for patterns, conventions, and decisions.
+
+- Use `{{KIRO_DIR}}/steering/` for project-wide policies: architecture principles, naming schemes, security constraints, tech stack decisions, api standards, etc.
+- Use local `AGENTS.md` files for feature or library context (e.g. `src/lib/payments/AGENTS.md`): describe domain assumptions, API contracts, or testing conventions specific to that folder. Codex auto-loads these when working in the matching path.
+- Specs notes stay with each spec (under `{{KIRO_DIR}}/specs/`) to guide specification-level workflows.
+
+## Project Context
+
+### Paths
+- Steering: `{{KIRO_DIR}}/steering/`
+- Specs: `{{KIRO_DIR}}/specs/`
+
+### Steering vs Specification
+
+**Steering** (`{{KIRO_DIR}}/steering/`) - Guide AI with project-wide rules and context
+**Specs** (`{{KIRO_DIR}}/specs/`) - Formalize development process for individual features
+
+### Active Specifications
+- Check `{{KIRO_DIR}}/specs/` for active specifications
+- Use `$kiro-spec-status <feature-name>` to check progress
+
+## Development Guidelines
+{{DEV_GUIDELINES}}
+
+## Minimal Workflow
+- Phase 0 (optional): `$kiro-steering`, `$kiro-steering-custom`
+- Phase 1 (Specification):
+  - `$kiro-spec-init "description"`
+  - `$kiro-spec-requirements {feature}`
+  - `$kiro-validate-gap {feature}` (optional: for existing codebase)
+  - `$kiro-spec-design {feature} [-y]`
+  - `$kiro-validate-design {feature}` (optional: design review)
+  - `$kiro-spec-tasks {feature} [-y]`
+- Phase 2 (Implementation): `$kiro-spec-impl {feature} [tasks]`
+  - `$kiro-validate-impl {feature}` (optional: after implementation)
+- Progress check: `$kiro-spec-status {feature}` (use anytime)
+
+## Development Rules
+- 3-phase approval workflow: Requirements → Design → Tasks → Implementation
+- Human review required each phase; use `-y` only for intentional fast-track
+- Keep steering current and verify alignment with `$kiro-spec-status <feature-name>`
+- Follow the user's instructions precisely, and within that scope act autonomously: gather the necessary context and complete the requested work end-to-end in this run, asking questions only when essential information is missing or the instructions are critically ambiguous.
+
+## Steering Configuration
+- Load entire `{{KIRO_DIR}}/steering/` as project memory
+- Default files: `product.md`, `tech.md`, `structure.md`
+- Custom files are supported (managed via `$kiro-steering-custom`)

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-spec-design/SKILL.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-spec-design/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: kiro-spec-design
+description: Create the technical design for a feature spec (design.md + research.md as needed) under {{KIRO_DIR}}/specs/<feature>/, using repo steering and templates.
+metadata:
+  short-description: Create design
+---
+
+# Kiro Spec Design
+
+## Usage
+
+- Invoke: `$kiro-spec-design <feature-name>`
+
+## Procedure
+
+1. Read context:
+   - `{{KIRO_DIR}}/specs/<feature>/spec.json`
+   - `{{KIRO_DIR}}/specs/<feature>/requirements.md`
+   - All steering: `{{KIRO_DIR}}/steering/*.md`
+2. Read templates/rules:
+   - `{{KIRO_DIR}}/settings/templates/specs/design.md`
+   - `{{KIRO_DIR}}/settings/templates/specs/research.md`
+   - `{{KIRO_DIR}}/settings/rules/design-principles.md` (if present)
+3. Produce:
+   - `research.md` for investigations/alternatives (when needed)
+   - `design.md` as the reviewable design: architecture, APIs, data model, risks, rollout
+4. Update `spec.json` metadata for the design phase (phase + timestamps/approvals as defined by templates).
+
+## Output
+
+- Summarize key design decisions and point to `design.md`.
+- Next step: `$kiro-spec-tasks <feature>` (optionally run `$kiro-validate-design <feature>` first).
+

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-spec-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-spec-impl/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: kiro-spec-impl
+description: Implement tasks for a feature spec following {{KIRO_DIR}}/specs/<feature>/{requirements,design,tasks}.md and repo steering; prefer tests first where applicable.
+metadata:
+  short-description: Implement spec tasks
+---
+
+# Kiro Spec Impl
+
+## Usage
+
+- Invoke: `$kiro-spec-impl <feature-name> [task-ids]`
+- If task IDs are provided, implement only those. Otherwise, implement the next pending tasks from `tasks.md`.
+
+## Procedure
+
+1. Read:
+   - `{{KIRO_DIR}}/specs/<feature>/requirements.md`
+   - `{{KIRO_DIR}}/specs/<feature>/design.md`
+   - `{{KIRO_DIR}}/specs/<feature>/tasks.md`
+   - All steering: `{{KIRO_DIR}}/steering/*.md`
+2. Implement incrementally:
+   - Prefer small PR-sized changes aligned to tasks
+   - Add/update tests where meaningful
+   - Keep docs/templates in sync if behavior changes
+3. After changes, run relevant project tests/linters (or describe how to run them if tooling isn’t available).
+
+## Output
+
+- List completed tasks, changed files, and how to verify.
+- Recommend `$kiro-validate-impl <feature>` after implementation.
+

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-spec-init/SKILL.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-spec-init/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: kiro-spec-init
+description: Initialize a new spec under {{KIRO_DIR}}/specs/ from a project description (creates spec.json and requirements.md seed).
+metadata:
+  short-description: Initialize a spec
+---
+
+# Kiro Spec Init
+
+## Usage
+
+- Invoke: `$kiro-spec-init <what-to-build>`
+- Input is the text after the skill name. If missing/too vague, ask 1–3 clarifying questions.
+
+## Procedure
+
+1. Check existing specs in `{{KIRO_DIR}}/specs/` to avoid name collisions.
+2. Generate a short, URL-safe feature name (kebab-case). If it already exists, append `-2`, `-3`, etc.
+3. Create `{{KIRO_DIR}}/specs/<feature>/`.
+4. Read templates:
+   - `{{KIRO_DIR}}/settings/templates/specs/init.json`
+   - `{{KIRO_DIR}}/settings/templates/specs/requirements-init.md`
+5. Replace placeholders:
+   - `{{FEATURE_NAME}}`, `{{TIMESTAMP}}` (ISO 8601), `{{PROJECT_DESCRIPTION}}`
+6. Write:
+   - `{{KIRO_DIR}}/specs/<feature>/spec.json`
+   - `{{KIRO_DIR}}/specs/<feature>/requirements.md`
+
+## Output
+
+- Confirm created paths.
+- Provide the next command: `$kiro-spec-requirements <feature>`.
+

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-spec-requirements/SKILL.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-spec-requirements/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: kiro-spec-requirements
+description: Generate testable requirements (EARS) for a feature spec in {{KIRO_DIR}}/specs/<feature>/requirements.md and update spec.json metadata.
+metadata:
+  short-description: Generate requirements
+---
+
+# Kiro Spec Requirements
+
+## Usage
+
+- Invoke: `$kiro-spec-requirements <feature-name>`
+
+## Procedure
+
+1. Read context:
+   - `{{KIRO_DIR}}/specs/<feature>/spec.json`
+   - `{{KIRO_DIR}}/specs/<feature>/requirements.md` (contains the initial description)
+   - All steering: `{{KIRO_DIR}}/steering/*.md`
+2. Read rules/templates:
+   - `{{KIRO_DIR}}/settings/rules/ears-format.md`
+   - `{{KIRO_DIR}}/settings/templates/specs/requirements.md`
+3. Replace the initial description with a complete, testable requirements set:
+   - Use EARS format for acceptance criteria.
+   - Focus on WHAT, not HOW.
+   - Requirement headings must have leading numeric IDs (no alphabetic labels).
+4. Update `spec.json`:
+   - `phase: "requirements-generated"`
+   - `approvals.requirements.generated: true`
+   - `updated_at` timestamp
+
+## Output
+
+- Summarize key requirement areas and point to the updated files.
+- Next step: `$kiro-spec-design <feature>` (optionally run `$kiro-validate-gap <feature>` first for brownfield).
+

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-spec-status/SKILL.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-spec-status/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: kiro-spec-status
+description: Summarize the current status of a feature spec by reading {{KIRO_DIR}}/specs/<feature>/spec.json and related artifacts.
+metadata:
+  short-description: Show spec status
+---
+
+# Kiro Spec Status
+
+## Usage
+
+- Invoke: `$kiro-spec-status <feature-name>`
+
+## Procedure
+
+1. Read `{{KIRO_DIR}}/specs/<feature>/spec.json`.
+2. Inspect presence/contents of:
+   - `requirements.md`, `design.md`, `research.md`, `tasks.md`
+3. Produce a short status summary:
+   - Current phase
+   - What’s approved vs pending
+   - Suggested next command
+

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-spec-tasks/SKILL.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-spec-tasks/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: kiro-spec-tasks
+description: Break an approved design into executable implementation tasks in {{KIRO_DIR}}/specs/<feature>/tasks.md with dependencies and parallelizable work.
+metadata:
+  short-description: Plan tasks
+---
+
+# Kiro Spec Tasks
+
+## Usage
+
+- Invoke: `$kiro-spec-tasks <feature-name>`
+
+## Procedure
+
+1. Read:
+   - `{{KIRO_DIR}}/specs/<feature>/spec.json`
+   - `{{KIRO_DIR}}/specs/<feature>/requirements.md`
+   - `{{KIRO_DIR}}/specs/<feature>/design.md` (and `research.md` if present)
+   - All steering: `{{KIRO_DIR}}/steering/*.md`
+2. Read templates/rules:
+   - `{{KIRO_DIR}}/settings/templates/specs/tasks.md`
+   - `{{KIRO_DIR}}/settings/rules/tasks-parallel-analysis.md`
+3. Generate `tasks.md`:
+   - Small, verifiable tasks with clear acceptance criteria
+   - Explicit dependencies
+   - Mark parallelizable tasks per rules
+4. Update `spec.json` metadata for the tasks phase.
+
+## Output
+
+- Summarize the plan (task count, key milestones) and point to `tasks.md`.
+- Next step: `$kiro-spec-impl <feature> [tasks]`.
+

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-steering-custom/SKILL.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-steering-custom/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: kiro-steering-custom
+description: Add a custom steering document under {{KIRO_DIR}}/steering/ for domain-specific rules (APIs, security, testing, naming, etc.).
+metadata:
+  short-description: Create custom steering
+---
+
+# Kiro Steering Custom
+
+## Usage
+
+- Invoke: `$kiro-steering-custom <what-to-create>`
+- If the request is unclear, propose 2–3 candidate steering docs and ask which to create.
+
+## Procedure
+
+1. Read existing steering: `{{KIRO_DIR}}/steering/*.md`.
+2. Choose a filename and scope (e.g., `api-standards.md`, `security.md`, `testing.md`).
+3. Use `{{KIRO_DIR}}/settings/templates/steering/` as structure guide when applicable.
+4. Write the new steering doc with concrete, enforceable rules and examples.
+
+## Output
+
+- Confirm the created file path and how it affects future specs/implementation.
+

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-steering/SKILL.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-steering/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: kiro-steering
+description: Create or update project steering docs in {{KIRO_DIR}}/steering/ as persistent project memory (product, tech, structure, and custom files).
+metadata:
+  short-description: Update steering
+---
+
+# Kiro Steering
+
+## Usage
+
+- Invoke: `$kiro-steering`
+
+## Procedure
+
+1. Detect scenario:
+   - Bootstrap: steering missing/empty
+   - Sync: steering exists (update additively)
+2. Read templates/rules:
+   - `{{KIRO_DIR}}/settings/templates/steering/*`
+   - `{{KIRO_DIR}}/settings/rules/steering-principles.md`
+3. Analyze the codebase just-in-time (search/read) to capture patterns, not catalogs.
+4. Write/update `{{KIRO_DIR}}/steering/*.md` additively; preserve user customizations.
+
+## Output
+
+- Summarize what changed and highlight any drift or follow-up recommendations.
+

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-validate-design/SKILL.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-validate-design/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: kiro-validate-design
+description: Validate the design ({{KIRO_DIR}}/specs/<feature>/design.md) against the existing codebase and steering rules to catch integration issues early.
+metadata:
+  short-description: Validate design
+---
+
+# Kiro Validate Design
+
+## Usage
+
+- Invoke: `$kiro-validate-design <feature-name>`
+
+## Procedure
+
+1. Read:
+   - `{{KIRO_DIR}}/specs/<feature>/spec.json`
+   - `{{KIRO_DIR}}/specs/<feature>/design.md` (and `research.md` if present)
+   - All steering: `{{KIRO_DIR}}/steering/*.md`
+2. Inspect the codebase for integration constraints (APIs, module boundaries, DB, auth, etc.).
+3. Identify mismatches, missing migration steps, unsafe assumptions, and operational risks.
+4. Propose concrete fixes to the design (do not implement code here).
+
+## Output
+
+- Report compatibility findings and recommended design changes.
+- Next step: update `design.md` if needed, then `$kiro-spec-tasks <feature>`.
+

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-validate-gap/SKILL.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-validate-gap/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: kiro-validate-gap
+description: Analyze the implementation gap between {{KIRO_DIR}}/specs/<feature>/requirements.md and the existing codebase, following {{KIRO_DIR}}/settings/rules/gap-analysis.md.
+metadata:
+  short-description: Validate gap
+---
+
+# Kiro Validate Gap
+
+## Usage
+
+- Invoke: `$kiro-validate-gap <feature-name>`
+
+## Procedure
+
+1. Read context:
+   - `{{KIRO_DIR}}/specs/<feature>/spec.json`
+   - `{{KIRO_DIR}}/specs/<feature>/requirements.md`
+   - All steering: `{{KIRO_DIR}}/steering/*.md`
+2. Read analysis framework:
+   - `{{KIRO_DIR}}/settings/rules/gap-analysis.md`
+3. Inspect the codebase (search + read) to identify:
+   - Existing components/services that already meet requirements
+   - Missing capabilities and integration points
+   - Viable approaches (extend vs new vs hybrid) and trade-offs
+   - Research needed for design phase
+
+## Output
+
+- Produce a concise summary plus a structured gap analysis per `gap-analysis.md`.
+- Next step: `$kiro-spec-design <feature>`.
+

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-validate-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-validate-impl/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: kiro-validate-impl
+description: Validate the implementation against requirements, design, and tasks for {{KIRO_DIR}}/specs/<feature>/ and report gaps, regressions, and follow-ups.
+metadata:
+  short-description: Validate implementation
+---
+
+# Kiro Validate Impl
+
+## Usage
+
+- Invoke: `$kiro-validate-impl <feature-name>`
+
+## Procedure
+
+1. Read:
+   - `{{KIRO_DIR}}/specs/<feature>/requirements.md`
+   - `{{KIRO_DIR}}/specs/<feature>/design.md`
+   - `{{KIRO_DIR}}/specs/<feature>/tasks.md`
+   - All steering: `{{KIRO_DIR}}/steering/*.md`
+2. Inspect the codebase to verify:
+   - Requirements coverage (including edge cases)
+   - Design alignment (APIs, data model, security, ops)
+   - Task completion status matches actual code
+3. Identify gaps and propose concrete follow-up tasks.
+
+## Output
+
+- Provide a checklist-style report with pass/fail/unknown per requirement and key design points.
+

--- a/tools/cc-sdd/templates/manifests/codex-skills.json
+++ b/tools/cc-sdd/templates/manifests/codex-skills.json
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "artifacts": [
+    {
+      "id": "skills",
+      "source": {
+        "type": "templateDir",
+        "fromDir": "templates/agents/{{AGENT}}/skills",
+        "toDir": "{{AGENT_COMMANDS_DIR}}"
+      },
+      "when": { "agent": "codex-skills" }
+    },
+    {
+      "id": "doc_main",
+      "source": {
+        "type": "templateFile",
+        "from": "templates/agents/{{AGENT}}/docs/AGENTS.md",
+        "toDir": ".",
+        "rename": "{{AGENT_DOC}}"
+      },
+      "when": { "agent": "codex-skills" }
+    },
+    {
+      "id": "settings_common",
+      "source": {
+        "type": "templateDir",
+        "fromDir": "templates/shared/settings",
+        "toDir": "{{KIRO_DIR}}/settings"
+      },
+      "when": { "agent": "codex-skills" }
+    }
+  ]
+}
+

--- a/tools/cc-sdd/test/agentLayout.test.ts
+++ b/tools/cc-sdd/test/agentLayout.test.ts
@@ -32,6 +32,15 @@ describe('resolveAgentLayout', () => {
       docFile: 'GEMINI.md',
     });
   });
+
+  it('returns defaults for codex-skills', () => {
+    const res = resolveAgentLayout('codex-skills');
+    expect(res).toEqual({
+      commandsDir: '.codex/skills',
+      agentDir: '.codex',
+      docFile: 'AGENTS.md',
+    });
+  });
   it('returns defaults for cursor', () => {
     const res = resolveAgentLayout('cursor');
     expect(res).toEqual({

--- a/tools/cc-sdd/test/args.test.ts
+++ b/tools/cc-sdd/test/args.test.ts
@@ -44,9 +44,11 @@ describe('parseArgs', () => {
     expect(parseArgs(['--claude-agent']).agent).toBe('claude-code-agent');
     expect(parseArgs(['--claude-code-agent']).agent).toBe('claude-code-agent');
     expect(parseArgs(['--windsurf']).agent).toBe('windsurf');
+    expect(parseArgs(['--codex-skills']).agent).toBe('codex-skills');
 
     expect(() => parseArgs(['--agent', 'qwen-code', '--gemini-cli'])).toThrowError(/agent.*conflict/i);
     expect(() => parseArgs(['--gemini-cli', '--qwen-code'])).toThrowError(/agent.*conflict/i);
+    expect(() => parseArgs(['--agent', 'codex', '--codex-skills'])).toThrowError(/agent.*conflict/i);
   });
 
   it('validates enum values for os/lang/overwrite/agent', () => {

--- a/tools/cc-sdd/test/realManifestCodexSkills.test.ts
+++ b/tools/cc-sdd/test/realManifestCodexSkills.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { runCli } from '../src/index';
+import { mkdtemp, readFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const runtime = { platform: 'darwin' } as const;
+
+const makeIO = () => {
+  const logs: string[] = [];
+  const errs: string[] = [];
+  return {
+    io: {
+      log: (m: string) => logs.push(m),
+      error: (m: string) => errs.push(m),
+      exit: (_c: number) => {},
+    },
+    get logs() {
+      return logs;
+    },
+    get errs() {
+      return errs;
+    },
+  };
+};
+
+const mkTmp = async () => mkdtemp(join(tmpdir(), 'ccsdd-real-manifest-codex-skills-'));
+const exists = async (p: string) => {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+// vitest runs in tools/cc-sdd; repoRoot is two levels up
+const repoRoot = join(process.cwd(), '..', '..');
+const manifestPath = join(repoRoot, 'tools/cc-sdd/templates/manifests/codex-skills.json');
+
+describe('real codex-skills manifest', () => {
+  it('dry-run prints plan for codex-skills.json with placeholders applied', async () => {
+    const ctx = makeIO();
+    const code = await runCli(
+      ['--dry-run', '--lang', 'en', '--agent', 'codex-skills', '--manifest', manifestPath],
+      runtime,
+      ctx.io,
+      {},
+    );
+    expect(code).toBe(0);
+    const out = ctx.logs.join('\n');
+    expect(out).toMatch(/Plan \(dry-run\)/);
+    expect(out).toContain('[templateDir] skills: templates/agents/codex-skills/skills -> .codex/skills');
+    expect(out).toContain('[templateFile] doc_main: templates/agents/codex-skills/docs/AGENTS.md -> ./AGENTS.md');
+    expect(out).toContain('[templateDir] settings_common: templates/shared/settings -> .kiro/settings');
+  });
+
+  it('apply writes AGENTS.md, skills, and settings to cwd', async () => {
+    const cwd = await mkTmp();
+    const ctx = makeIO();
+    const code = await runCli(
+      ['--lang', 'en', '--agent', 'codex-skills', '--manifest', manifestPath, '--overwrite=force'],
+      runtime,
+      ctx.io,
+      {},
+      { cwd, templatesRoot: process.cwd() },
+    );
+    expect(code).toBe(0);
+
+    const doc = join(cwd, 'AGENTS.md');
+    expect(await exists(doc)).toBe(true);
+    const text = await readFile(doc, 'utf8');
+    expect(text).toMatch(/# AI-DLC and Spec-Driven Development/);
+
+    const skill = join(cwd, '.codex/skills/kiro-spec-init/SKILL.md');
+    expect(await exists(skill)).toBe(true);
+    const skillText = await readFile(skill, 'utf8');
+    expect(skillText).toMatch(/name: kiro-spec-init/);
+
+    const settingsTemplate = join(cwd, '.kiro/settings/templates/specs/init.json');
+    expect(await exists(settingsTemplate)).toBe(true);
+
+    expect(ctx.logs.join('\n')).toMatch(/Setup completed: written=\d+, skipped=\d+/);
+  });
+});
+


### PR DESCRIPTION
Custom prompts in Codex are now deprecated. Codex recommends using Agent Skills instead.
This PR adds the setup commands for Codex Agent Skills, so new setups follow the recommended approach.

https://developers.openai.com/codex/custom-prompts/#:~:text=Deprecated.%20Use%20skills%20for%20reusable%20prompts
