### PR TITLE
docs: remove Amazon book reference promoting ai-sdd

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ Common use cases: PRD-style requirements, API and database schemas, approval gat
 
 - [Kiro IDE](https://kiro.dev): enhanced spec management and team collaboration.
 - [Kiro's Spec Methodology](https://kiro.dev/docs/specs/): the original spec-driven development methodology.
-- [AI-Assisted SDD: Spec-Driven Development with Gemini, Claude, and cc-sdd](https://www.amazon.com/dp/B0CW19YX9R): comprehensive book on Amazon.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Removes the link to the Amazon book, which was originally titled *AI-Assisted SDD: Spec-Driven Development with Gemini, Claude, and cc-sdd* but has since been retitled to *AI-Assisted SDD: Spec-Driven Development with Gemini, Claude, and **ai-sdd***
- The book now promotes **ai-sdd**, an NPM library that is a closed-source clone of cc-sdd with no attribution to this project

🤖 Generated with [Claude Code](https://claude.com/claude-code)