### PR TITLE
[codex] fix spec-reviewer role description

### DIFF
--- a/tools/cc-sdd/templates/agents/codex-skills/codex-agents/spec-reviewer.toml
+++ b/tools/cc-sdd/templates/agents/codex-skills/codex-agents/spec-reviewer.toml
@@ -1,4 +1,8 @@
 name = "spec-reviewer"
+description = """
+Use for cross-spec consistency review across multiple generated specifications.
+Detect contradictions, overlap, interface mismatches, and boundary problems between specs.
+"""
 model = "gpt-5.4"
 model_reasoning_effort = "high"
 developer_instructions = """


### PR DESCRIPTION
## Summary
- add a `description` field to the Codex `spec-reviewer` role template
- keep the description specific enough for Codex role selection guidance without tying it only to one call site

## Why
Codex requires custom agent roles to define `description`. The shipped `spec-reviewer.toml` template omitted it, which caused Codex to warn and ignore the malformed role definition.

## Impact
Codex installs now generate a valid `.codex/agents/spec-reviewer.toml`, so the cross-spec reviewer role remains available instead of being dropped at load time.

## Validation
- `npm test` in `tools/cc-sdd`
