### PR TITLE
Add configurable review modes to skills-based kiro-impl

### DIFF
--- a/tools/cc-sdd/templates/agents/antigravity-skills/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/antigravity-skills/docs/AGENTS.md
@@ -39,9 +39,10 @@ Project memory keeps persistent guidance (steering, specs notes, component docs)
     - `/kiro-validate-design {feature}` (optional: design review)
     - `/kiro-spec-tasks {feature} [-y]`
   - Multi-spec: `/kiro-spec-batch` — creates all specs from roadmap.md in parallel by dependency wave
-- Phase 2 (Implementation): `/kiro-impl {feature} [tasks]`
+- Phase 2 (Implementation): `/kiro-impl {feature} [tasks] [--review required|inline|off]`
   - Without task numbers: autonomous mode (subagent per task + independent review + final validation)
   - With task numbers: manual mode (selected tasks in main context, still reviewer-gated before completion)
+  - `--review off` skips task-local review; use it intentionally and keep `/kiro-validate-impl {feature}` as the final quality gate
   - `/kiro-validate-impl {feature}` (standalone re-validation)
 - Progress check: `/kiro-spec-status {feature}` (use anytime)
 

--- a/tools/cc-sdd/templates/agents/antigravity-skills/skills/kiro-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/antigravity-skills/skills/kiro-impl/SKILL.md
@@ -16,7 +16,12 @@ You operate in two modes:
   - Code passes all tests with no regressions
   - Tasks marked as completed in tasks.md
   - Implementation aligns with design and requirements
-  - Independent reviewer approves each task before completion
+  - Task completion follows the selected review mode
+- **Review Mode**:
+  - Default is `required`
+  - Accept explicit forms: `--review required|inline|off`
+  - Also accept clear natural-language opt-outs such as `skip review` or `without review` as `off`
+  - If the request is ambiguous, keep `required`
 </background_information>
 
 <instructions>
@@ -59,6 +64,10 @@ After all parallel research completes, synthesize implementation brief before st
 - Extract feature name from `$1`
 - If task numbers provided in `$2` (e.g., "1.1" or "1,2,3"): **manual mode**
 - If no task numbers: **autonomous mode** (all pending tasks)
+- Determine review mode from the invocation:
+  - `--review required` or omitted → `required`
+  - `--review inline` → `inline`
+  - `--review off`, `skip review`, or `without review` → `off`
 
 **Build task queue**:
 - Read tasks.md, identify actionable sub-tasks (X.Y numbering like 1.1, 2.3)
@@ -97,23 +106,33 @@ If multi-agent capability is available, for each task (one at a time):
 - **BLOCKED** → dispatch debug subagent (see section below); do NOT immediately skip
 - **NEEDS_CONTEXT** → re-dispatch once with the requested additional context; if still unresolved → dispatch debug subagent
 
-**c) Dispatch reviewer**:
-- Read `templates/reviewer-prompt.md` from this skill's directory
-- Construct a review prompt with:
-  - The task description and relevant spec section numbers
-  - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
-  - The implementer's status report (for reference only — reviewer must verify independently)
-- The reviewer must apply the `kiro-review` protocol to this task-local review.
-- Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
-- The reviewer sub-agent will run `git diff` itself to read the actual code changes and verify against the spec
-- Spawn a fresh sub-agent with this prompt
+**c) Review the task**:
+- If review mode is `required`:
+  - Read `templates/reviewer-prompt.md` from this skill's directory
+  - Construct a review prompt with:
+    - The task description and relevant spec section numbers
+    - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
+    - The implementer's status report (for reference only — reviewer must verify independently)
+  - The reviewer must apply the `kiro-review` protocol to this task-local review.
+  - Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
+  - The reviewer sub-agent will run `git diff` itself to read the actual code changes and verify against the spec
+  - Spawn a fresh sub-agent with this prompt
+- If review mode is `inline`:
+  - Apply `kiro-review` in the parent context using the same task evidence and the actual `git diff`
+- If review mode is `off`:
+  - Skip task-local review
+  - Record in the parent context that task-local review was skipped for this task
 
 **d) Handle reviewer verdict**:
-- Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
-- If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
-- **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
-- **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
-- **REJECTED (round 3)** → dispatch debug subagent (see section below)
+- If review mode is `off`:
+  - Do not fabricate a reviewer verdict
+  - Before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+- Otherwise:
+  - Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
+  - If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
+  - **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+  - **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
+  - **REJECTED (round 3)** → dispatch debug subagent (see section below)
 
 **e) Commit** (parent-only, selective staging):
 - Stage only the files actually changed for this task, plus tasks.md
@@ -169,8 +188,13 @@ Before writing any code, read the relevant sections of requirements.md and desig
 - **GREEN**: Implement simplest solution to make test pass, following the design constraints.
 - **REFACTOR**: Improve code structure, remove duplication. All tests must still pass.
 - **VERIFY**: All tests pass (new and existing), no regressions. Confirm verification method passes.
-- **REVIEW**: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
-- **MARK COMPLETE**: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+- **REVIEW**:
+  - `required`: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
+  - `inline`: Apply `kiro-review` in the main context before marking the task complete.
+  - `off`: Skip task-local review, but note that `kiro-validate-impl` becomes the primary quality gate before any feature-level completion claim.
+- **MARK COMPLETE**:
+  - `required|inline`: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+  - `off`: Apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
 
 ## Step 4: Final Validation
 
@@ -184,6 +208,7 @@ Before writing any code, read the relevant sections of requirements.md and desig
 
 **Manual mode**:
 - Suggest running `/kiro-validate-impl $1` but do not auto-execute
+- If review mode is `off`, treat `/kiro-validate-impl $1` as mandatory before any feature-level success claim
 
 ## Feature Flag Protocol
 

--- a/tools/cc-sdd/templates/agents/antigravity-skills/skills/kiro-validate-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/antigravity-skills/skills/kiro-validate-impl/SKILL.md
@@ -7,7 +7,7 @@ description: Validate feature-level integration after all tasks are implemented.
 # Implementation Integration Validation
 
 <background_information>
-Individual tasks have already been reviewed by the per-task reviewer during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
+Individual tasks are usually reviewed during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
 
 Boundary terminology continuity:
 - discovery identifies `Boundary Candidates`
@@ -23,7 +23,7 @@ Boundary terminology continuity:
   - Design structure is reflected end-to-end (not just per-component)
   - No orphaned code, conflicting implementations, integration seams, or boundary spillover
 
-**What This Skill Does NOT Do**: Per-task checks are the reviewer's responsibility during `/kiro-impl`. This skill does NOT re-check individual task acceptance criteria, per-file reality checks, or single-task spec alignment.
+**What This Skill Does NOT Do**: This skill is not a full replacement for task-local review during `/kiro-impl`. This skill does NOT re-check every individual task acceptance criterion, every per-file reality check, or every single-task spec detail unless a concrete integration finding forces it.
 
 This skill's main question is: when the completed tasks are viewed together, do they still respect the designed boundary seams and dependency direction?
 </background_information>
@@ -60,6 +60,8 @@ The following validation dimensions are independent and can be dispatched as **s
 If multi-agent is not available, run checks sequentially in main context.
 
 After all checks complete, synthesize findings for GO/NO-GO/MANUAL_VERIFY_REQUIRED assessment.
+
+If the implementation run explicitly skipped task-local review (for example `--review off`), tighten scrutiny on obvious task-level gaps that surface during integration validation and call out that reduced review coverage in the report.
 
 ### 2. Load Context
 

--- a/tools/cc-sdd/templates/agents/claude-code-skills/docs/CLAUDE.md
+++ b/tools/cc-sdd/templates/agents/claude-code-skills/docs/CLAUDE.md
@@ -32,9 +32,10 @@ Kiro-style Spec-Driven Development on an agentic SDLC
     - `/kiro-validate-design {feature}` (optional: design review)
     - `/kiro-spec-tasks {feature} [-y]`
   - Multi-spec: `/kiro-spec-batch` — creates all specs from roadmap.md in parallel by dependency wave
-- Phase 2 (Implementation): `/kiro-impl {feature} [tasks]`
+- Phase 2 (Implementation): `/kiro-impl {feature} [tasks] [--review required|inline|off]`
   - Without task numbers: autonomous mode (subagent per task + independent review + final validation)
   - With task numbers: manual mode (selected tasks in main context, still reviewer-gated before completion)
+  - `--review off` skips task-local review; use it intentionally and keep `/kiro-validate-impl {feature}` as the final quality gate
   - `/kiro-validate-impl {feature}` (standalone re-validation)
 - Progress check: `/kiro-spec-status {feature}` (use anytime)
 

--- a/tools/cc-sdd/templates/agents/claude-code-skills/skills/kiro-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/claude-code-skills/skills/kiro-impl/SKILL.md
@@ -3,7 +3,7 @@ name: kiro-impl
 description: Implement approved tasks using TDD with native subagent dispatch. Runs all pending tasks autonomously or selected tasks manually.
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, MultiEdit, Bash, Glob, Grep, Agent, WebSearch, WebFetch
-argument-hint: <feature-name> [task-numbers]
+argument-hint: <feature-name> [task-numbers] [--review required|inline|off]
 ---
 
 # kiro-impl Skill
@@ -19,7 +19,13 @@ You operate in two modes:
   - Code passes all tests with no regressions
   - Tasks marked as completed in tasks.md
   - Implementation aligns with design and requirements
-  - Independent reviewer approves each task before completion
+  - Task completion follows the selected review mode
+
+## Review Mode
+- Default review mode is `required`
+- Accept explicit forms: `--review required|inline|off`
+- Also accept clear natural-language opt-outs such as `skip review` or `without review` as `off`
+- If the request is ambiguous, keep `required`
 
 ## Execution Steps
 
@@ -61,6 +67,10 @@ After all parallel research completes, synthesize implementation brief before st
 - Extract feature name from first argument
 - If task numbers provided (e.g., "1.1" or "1,2,3"): **manual mode**
 - If no task numbers: **autonomous mode** (all pending tasks)
+- Determine review mode from the invocation:
+  - `--review required` or omitted → `required`
+  - `--review inline` → `inline`
+  - `--review off`, `skip review`, or `without review` → `off`
 
 **Build task queue**:
 - Read tasks.md, identify actionable sub-tasks (X.Y numbering like 1.1, 2.3)
@@ -99,23 +109,33 @@ For each task (one at a time):
 - **BLOCKED** → dispatch debug subagent (see section below); do NOT immediately skip
 - **NEEDS_CONTEXT** → re-dispatch once with the requested additional context; if still unresolved → dispatch debug subagent
 
-**c) Dispatch reviewer**:
-- Read `templates/reviewer-prompt.md` from this skill's directory
-- Construct a review prompt with:
-  - The task description and relevant spec section numbers
-  - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
-  - The implementer's status report (for reference only — reviewer must verify independently)
-- The reviewer must apply the `kiro-review` protocol to this task-local review.
-- Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
-- The reviewer subagent will run `git diff` itself to read the actual code changes and verify against the spec
-- Dispatch via **Agent tool** as a fresh subagent
+**c) Review the task**:
+- If review mode is `required`:
+  - Read `templates/reviewer-prompt.md` from this skill's directory
+  - Construct a review prompt with:
+    - The task description and relevant spec section numbers
+    - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
+    - The implementer's status report (for reference only — reviewer must verify independently)
+  - The reviewer must apply the `kiro-review` protocol to this task-local review.
+  - Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
+  - The reviewer subagent will run `git diff` itself to read the actual code changes and verify against the spec
+  - Dispatch via **Agent tool** as a fresh subagent
+- If review mode is `inline`:
+  - Apply `kiro-review` in the parent context using the same task evidence and the actual `git diff`
+- If review mode is `off`:
+  - Skip task-local review
+  - Record in the parent context that task-local review was skipped for this task
 
 **d) Handle reviewer verdict**:
-- Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
-- If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
-- **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
-- **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
-- **REJECTED (round 3)** → dispatch debug subagent (see section below)
+- If review mode is `off`:
+  - Do not fabricate a reviewer verdict
+  - Before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+- Otherwise:
+  - Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
+  - If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
+  - **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+  - **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
+  - **REJECTED (round 3)** → dispatch debug subagent (see section below)
 
 **e) Commit** (parent-only, selective staging):
 - Stage only the files actually changed for this task, plus tasks.md
@@ -171,8 +191,13 @@ Before writing any code, read the relevant sections of requirements.md and desig
 - **GREEN**: Implement simplest solution to make test pass, following the design constraints.
 - **REFACTOR**: Improve code structure, remove duplication. All tests must still pass.
 - **VERIFY**: All tests pass (new and existing), no regressions. Confirm verification method passes.
-- **REVIEW**: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
-- **MARK COMPLETE**: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+- **REVIEW**:
+  - `required`: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
+  - `inline`: Apply `kiro-review` in the main context before marking the task complete.
+  - `off`: Skip task-local review, but note that `kiro-validate-impl` becomes the primary quality gate before any feature-level completion claim.
+- **MARK COMPLETE**:
+  - `required|inline`: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+  - `off`: Apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
 
 ### Step 4: Final Validation
 
@@ -186,6 +211,7 @@ Before writing any code, read the relevant sections of requirements.md and desig
 
 **Manual mode**:
 - Suggest running `/kiro-validate-impl {feature}` but do not auto-execute
+- If review mode is `off`, treat `/kiro-validate-impl {feature}` as mandatory before any feature-level success claim
 
 ## Feature Flag Protocol
 

--- a/tools/cc-sdd/templates/agents/claude-code-skills/skills/kiro-validate-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/claude-code-skills/skills/kiro-validate-impl/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: <feature-name> [task-numbers]
 # kiro-validate-impl Skill
 
 ## Role
-Individual tasks have already been reviewed by the per-task reviewer during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
+Individual tasks are usually reviewed during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
 
 Boundary terminology continuity:
 - discovery identifies `Boundary Candidates`
@@ -26,7 +26,7 @@ Boundary terminology continuity:
   - No orphaned code, conflicting implementations, integration seams, or boundary spillover
 
 ## What This Skill Does NOT Do
-Per-task checks are the reviewer's responsibility during `/kiro-impl`. This skill does **not** re-check:
+This skill is not a full replacement for task-local review during `/kiro-impl`. This skill does **not** re-check:
 - Individual task acceptance criteria
 - Per-file reality checks (mock/stub detection)
 - Single-task spec alignment
@@ -80,6 +80,8 @@ The following validation dimensions are independent and can be dispatched as **s
 - **Cross-task integration**: Verify data flows, API contracts, shared state consistency
 
 For simple features (few tasks, small scope), run checks in main context without subagent dispatch.
+
+If the implementation run explicitly skipped task-local review (for example `--review off`), tighten scrutiny on obvious task-level gaps that surface during integration validation and call out that reduced review coverage in the report.
 
 #### Mechanical Checks (run commands, use results)
 

--- a/tools/cc-sdd/templates/agents/codex-skills/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/docs/AGENTS.md
@@ -39,9 +39,10 @@ Project memory keeps persistent guidance (steering, specs notes, component docs)
     - `$kiro-validate-design {feature}` (optional: design review)
     - `$kiro-spec-tasks {feature} [-y]`
   - Multi-spec: `$kiro-spec-batch` — creates all specs from roadmap.md in parallel by dependency wave
-- Phase 2 (Implementation): `$kiro-impl {feature} [tasks]`
+- Phase 2 (Implementation): `$kiro-impl {feature} [tasks] [--review required|inline|off]`
   - Without task numbers: autonomous mode (subagent per task + independent review + final validation)
   - With task numbers: manual mode (selected tasks in main context, still reviewer-gated before completion)
+  - `--review off` skips task-local review; use it intentionally and keep `$kiro-validate-impl {feature}` as the final quality gate
   - `$kiro-validate-impl {feature}` (standalone re-validation)
 - Progress check: `$kiro-spec-status {feature}` (use anytime)
 

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-impl/SKILL.md
@@ -16,7 +16,12 @@ You operate in two modes:
   - Code passes all tests with no regressions
   - Tasks marked as completed in tasks.md
   - Implementation aligns with design and requirements
-  - Independent reviewer approves each task before completion
+  - Task completion follows the selected review mode
+- **Review Mode**:
+  - Default is `required`
+  - Accept explicit forms: `--review required|inline|off`
+  - Also accept clear natural-language opt-outs such as `skip review` or `without review` as `off`
+  - If the request is ambiguous, keep `required`
 </background_information>
 
 <instructions>
@@ -59,6 +64,10 @@ After all parallel research completes, synthesize implementation brief before st
 - Extract feature name from `$1`
 - If task numbers provided in `$2` (e.g., "1.1" or "1,2,3"): **manual mode**
 - If no task numbers: **autonomous mode** (all pending tasks)
+- Determine review mode from the invocation:
+  - `--review required` or omitted → `required`
+  - `--review inline` → `inline`
+  - `--review off`, `skip review`, or `without review` → `off`
 
 **Build task queue**:
 - Read tasks.md, identify actionable sub-tasks (X.Y numbering like 1.1, 2.3)
@@ -97,23 +106,33 @@ If multi-agent capability is available, for each task (one at a time):
 - **BLOCKED** → dispatch debug subagent (see section below); do NOT immediately skip
 - **NEEDS_CONTEXT** → re-dispatch once with the requested additional context; if still unresolved → dispatch debug subagent
 
-**c) Dispatch reviewer**:
-- Read `templates/reviewer-prompt.md` from this skill's directory
-- Construct a review prompt with:
-  - The task description and relevant spec section numbers
-  - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
-  - The implementer's status report (for reference only — reviewer must verify independently)
-- The reviewer must apply the `kiro-review` protocol to this task-local review.
-- Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
-- The reviewer sub-agent will run `git diff` itself to read the actual code changes and verify against the spec
-- Spawn a fresh sub-agent with this prompt
+**c) Review the task**:
+- If review mode is `required`:
+  - Read `templates/reviewer-prompt.md` from this skill's directory
+  - Construct a review prompt with:
+    - The task description and relevant spec section numbers
+    - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
+    - The implementer's status report (for reference only — reviewer must verify independently)
+  - The reviewer must apply the `kiro-review` protocol to this task-local review.
+  - Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
+  - The reviewer sub-agent will run `git diff` itself to read the actual code changes and verify against the spec
+  - Spawn a fresh sub-agent with this prompt
+- If review mode is `inline`:
+  - Apply `kiro-review` in the parent context using the same task evidence and the actual `git diff`
+- If review mode is `off`:
+  - Skip task-local review
+  - Record in the parent context that task-local review was skipped for this task
 
 **d) Handle reviewer verdict**:
-- Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
-- If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
-- **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
-- **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
-- **REJECTED (round 3)** → dispatch debug subagent (see section below)
+- If review mode is `off`:
+  - Do not fabricate a reviewer verdict
+  - Before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+- Otherwise:
+  - Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
+  - If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
+  - **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+  - **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
+  - **REJECTED (round 3)** → dispatch debug subagent (see section below)
 
 **e) Commit** (parent-only, selective staging):
 - Stage only the files actually changed for this task, plus tasks.md
@@ -169,8 +188,13 @@ Before writing any code, read the relevant sections of requirements.md and desig
 - **GREEN**: Implement simplest solution to make test pass, following the design constraints.
 - **REFACTOR**: Improve code structure, remove duplication. All tests must still pass.
 - **VERIFY**: All tests pass (new and existing), no regressions. Confirm verification method passes.
-- **REVIEW**: Apply `kiro-review` before marking the task complete. If the host supports fresh sub-agents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
-- **MARK COMPLETE**: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+- **REVIEW**:
+  - `required`: Apply `kiro-review` before marking the task complete. If the host supports fresh sub-agents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
+  - `inline`: Apply `kiro-review` in the main context before marking the task complete.
+  - `off`: Skip task-local review, but note that `kiro-validate-impl` becomes the primary quality gate before any feature-level completion claim.
+- **MARK COMPLETE**:
+  - `required|inline`: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+  - `off`: Apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
 
 ## Step 4: Final Validation
 
@@ -184,6 +208,7 @@ Before writing any code, read the relevant sections of requirements.md and desig
 
 **Manual mode**:
 - Suggest running `$kiro-validate-impl $1` but do not auto-execute
+- If review mode is `off`, treat `$kiro-validate-impl $1` as mandatory before any feature-level success claim
 
 ## Feature Flag Protocol
 

--- a/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-validate-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/codex-skills/skills/kiro-validate-impl/SKILL.md
@@ -7,7 +7,7 @@ description: Validate feature-level integration after all tasks are implemented.
 # Implementation Integration Validation
 
 <background_information>
-Individual tasks have already been reviewed by the per-task reviewer during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
+Individual tasks are usually reviewed during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
 
 Boundary terminology continuity:
 - discovery identifies `Boundary Candidates`
@@ -23,7 +23,7 @@ Boundary terminology continuity:
   - Design structure is reflected end-to-end (not just per-component)
   - No orphaned code, conflicting implementations, integration seams, or boundary spillover
 
-**What This Skill Does NOT Do**: Per-task checks are the reviewer's responsibility during `$kiro-impl`. This skill does NOT re-check individual task acceptance criteria, per-file reality checks, or single-task spec alignment.
+**What This Skill Does NOT Do**: This skill is not a full replacement for task-local review during `$kiro-impl`. It does NOT re-check every individual task acceptance criterion, every per-file reality check, or every single-task spec detail unless a concrete integration finding forces it.
 
 This skill's main question is: when the completed tasks are viewed together, do they still respect the designed boundary seams and dependency direction?
 </background_information>
@@ -60,6 +60,8 @@ The following validation dimensions are independent and can be dispatched as **s
 If multi-agent is not available, run checks sequentially in main context.
 
 After all checks complete, synthesize findings for GO/NO-GO/MANUAL_VERIFY_REQUIRED assessment.
+
+If the implementation run explicitly skipped task-local review (for example `--review off`), tighten scrutiny on obvious task-level gaps that surface during integration validation and call out that reduced review coverage in the report.
 
 ### 2. Load Context
 

--- a/tools/cc-sdd/templates/agents/cursor-skills/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/cursor-skills/docs/AGENTS.md
@@ -39,9 +39,10 @@ Project memory keeps persistent guidance (steering, specs notes, component docs)
     - `/kiro-validate-design {feature}` (optional: design review)
     - `/kiro-spec-tasks {feature} [-y]`
   - Multi-spec: `/kiro-spec-batch` — creates all specs from roadmap.md in parallel by dependency wave
-- Phase 2 (Implementation): `/kiro-impl {feature} [tasks]`
+- Phase 2 (Implementation): `/kiro-impl {feature} [tasks] [--review required|inline|off]`
   - Without task numbers: autonomous mode (subagent per task + independent review + final validation)
   - With task numbers: manual mode (selected tasks in main context, still reviewer-gated before completion)
+  - `--review off` skips task-local review; use it intentionally and keep `/kiro-validate-impl {feature}` as the final quality gate
   - `/kiro-validate-impl {feature}` (standalone re-validation)
 - Progress check: `/kiro-spec-status {feature}` (use anytime)
 

--- a/tools/cc-sdd/templates/agents/cursor-skills/skills/kiro-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/cursor-skills/skills/kiro-impl/SKILL.md
@@ -16,7 +16,12 @@ You operate in two modes:
   - Code passes all tests with no regressions
   - Tasks marked as completed in tasks.md
   - Implementation aligns with design and requirements
-  - Independent reviewer approves each task before completion
+  - Task completion follows the selected review mode
+- **Review Mode**:
+  - Default is `required`
+  - Accept explicit forms: `--review required|inline|off`
+  - Also accept clear natural-language opt-outs such as `skip review` or `without review` as `off`
+  - If the request is ambiguous, keep `required`
 </background_information>
 
 <instructions>
@@ -59,6 +64,10 @@ After all parallel research completes, synthesize implementation brief before st
 - Extract feature name from `$1`
 - If task numbers provided in `$2` (e.g., "1.1" or "1,2,3"): **manual mode**
 - If no task numbers: **autonomous mode** (all pending tasks)
+- Determine review mode from the invocation:
+  - `--review required` or omitted → `required`
+  - `--review inline` → `inline`
+  - `--review off`, `skip review`, or `without review` → `off`
 
 **Build task queue**:
 - Read tasks.md, identify actionable sub-tasks (X.Y numbering like 1.1, 2.3)
@@ -97,23 +106,33 @@ If multi-agent capability is available, for each task (one at a time):
 - **BLOCKED** → dispatch debug subagent (see section below); do NOT immediately skip
 - **NEEDS_CONTEXT** → re-dispatch once with the requested additional context; if still unresolved → dispatch debug subagent
 
-**c) Dispatch reviewer**:
-- Read `templates/reviewer-prompt.md` from this skill's directory
-- Construct a review prompt with:
-  - The task description and relevant spec section numbers
-  - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
-  - The implementer's status report (for reference only — reviewer must verify independently)
-- The reviewer must apply the `kiro-review` protocol to this task-local review.
-- Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
-- The reviewer sub-agent will run `git diff` itself to read the actual code changes and verify against the spec
-- Spawn a fresh sub-agent with this prompt
+**c) Review the task**:
+- If review mode is `required`:
+  - Read `templates/reviewer-prompt.md` from this skill's directory
+  - Construct a review prompt with:
+    - The task description and relevant spec section numbers
+    - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
+    - The implementer's status report (for reference only — reviewer must verify independently)
+  - The reviewer must apply the `kiro-review` protocol to this task-local review.
+  - Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
+  - The reviewer sub-agent will run `git diff` itself to read the actual code changes and verify against the spec
+  - Spawn a fresh sub-agent with this prompt
+- If review mode is `inline`:
+  - Apply `kiro-review` in the parent context using the same task evidence and the actual `git diff`
+- If review mode is `off`:
+  - Skip task-local review
+  - Record in the parent context that task-local review was skipped for this task
 
 **d) Handle reviewer verdict**:
-- Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
-- If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
-- **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
-- **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
-- **REJECTED (round 3)** → dispatch debug subagent (see section below)
+- If review mode is `off`:
+  - Do not fabricate a reviewer verdict
+  - Before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+- Otherwise:
+  - Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
+  - If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
+  - **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+  - **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
+  - **REJECTED (round 3)** → dispatch debug subagent (see section below)
 
 **e) Commit** (parent-only, selective staging):
 - Stage only the files actually changed for this task, plus tasks.md
@@ -169,8 +188,13 @@ Before writing any code, read the relevant sections of requirements.md and desig
 - **GREEN**: Implement simplest solution to make test pass, following the design constraints.
 - **REFACTOR**: Improve code structure, remove duplication. All tests must still pass.
 - **VERIFY**: All tests pass (new and existing), no regressions. Confirm verification method passes.
-- **REVIEW**: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
-- **MARK COMPLETE**: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+- **REVIEW**:
+  - `required`: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
+  - `inline`: Apply `kiro-review` in the main context before marking the task complete.
+  - `off`: Skip task-local review, but note that `kiro-validate-impl` becomes the primary quality gate before any feature-level completion claim.
+- **MARK COMPLETE**:
+  - `required|inline`: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+  - `off`: Apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
 
 ## Step 4: Final Validation
 
@@ -184,6 +208,7 @@ Before writing any code, read the relevant sections of requirements.md and desig
 
 **Manual mode**:
 - Suggest running `/kiro-validate-impl $1` but do not auto-execute
+- If review mode is `off`, treat `/kiro-validate-impl $1` as mandatory before any feature-level success claim
 
 ## Feature Flag Protocol
 

--- a/tools/cc-sdd/templates/agents/cursor-skills/skills/kiro-validate-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/cursor-skills/skills/kiro-validate-impl/SKILL.md
@@ -7,7 +7,7 @@ description: Validate feature-level integration after all tasks are implemented.
 # Implementation Integration Validation
 
 <background_information>
-Individual tasks have already been reviewed by the per-task reviewer during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
+Individual tasks are usually reviewed during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
 
 Boundary terminology continuity:
 - discovery identifies `Boundary Candidates`
@@ -23,7 +23,7 @@ Boundary terminology continuity:
   - Design structure is reflected end-to-end (not just per-component)
   - No orphaned code, conflicting implementations, integration seams, or boundary spillover
 
-**What This Skill Does NOT Do**: Per-task checks are the reviewer's responsibility during `/kiro-impl`. This skill does NOT re-check individual task acceptance criteria, per-file reality checks, or single-task spec alignment.
+**What This Skill Does NOT Do**: This skill is not a full replacement for task-local review during `/kiro-impl`. This skill does NOT re-check every individual task acceptance criterion, every per-file reality check, or every single-task spec detail unless a concrete integration finding forces it.
 
 This skill's main question is: when the completed tasks are viewed together, do they still respect the designed boundary seams and dependency direction?
 </background_information>
@@ -60,6 +60,8 @@ The following validation dimensions are independent and can be dispatched as **s
 If multi-agent is not available, run checks sequentially in main context.
 
 After all checks complete, synthesize findings for GO/NO-GO/MANUAL_VERIFY_REQUIRED assessment.
+
+If the implementation run explicitly skipped task-local review (for example `--review off`), tighten scrutiny on obvious task-level gaps that surface during integration validation and call out that reduced review coverage in the report.
 
 ### 2. Load Context
 

--- a/tools/cc-sdd/templates/agents/gemini-cli-skills/docs/GEMINI.md
+++ b/tools/cc-sdd/templates/agents/gemini-cli-skills/docs/GEMINI.md
@@ -39,9 +39,10 @@ Project memory keeps persistent guidance (steering, specs notes, component docs)
     - `/kiro-validate-design {feature}` (optional: design review)
     - `/kiro-spec-tasks {feature} [-y]`
   - Multi-spec: `/kiro-spec-batch` — creates all specs from roadmap.md in parallel by dependency wave
-- Phase 2 (Implementation): `/kiro-impl {feature} [tasks]`
+- Phase 2 (Implementation): `/kiro-impl {feature} [tasks] [--review required|inline|off]`
   - Without task numbers: autonomous mode (subagent per task + independent review + final validation)
   - With task numbers: manual mode (selected tasks in main context, still reviewer-gated before completion)
+  - `--review off` skips task-local review; use it intentionally and keep `/kiro-validate-impl {feature}` as the final quality gate
   - `/kiro-validate-impl {feature}` (standalone re-validation)
 - Progress check: `/kiro-spec-status {feature}` (use anytime)
 

--- a/tools/cc-sdd/templates/agents/gemini-cli-skills/skills/kiro-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/gemini-cli-skills/skills/kiro-impl/SKILL.md
@@ -16,7 +16,12 @@ You operate in two modes:
   - Code passes all tests with no regressions
   - Tasks marked as completed in tasks.md
   - Implementation aligns with design and requirements
-  - Independent reviewer approves each task before completion
+  - Task completion follows the selected review mode
+- **Review Mode**:
+  - Default is `required`
+  - Accept explicit forms: `--review required|inline|off`
+  - Also accept clear natural-language opt-outs such as `skip review` or `without review` as `off`
+  - If the request is ambiguous, keep `required`
 </background_information>
 
 <instructions>
@@ -59,6 +64,10 @@ After all parallel research completes, synthesize implementation brief before st
 - Extract feature name from `$1`
 - If task numbers provided in `$2` (e.g., "1.1" or "1,2,3"): **manual mode**
 - If no task numbers: **autonomous mode** (all pending tasks)
+- Determine review mode from the invocation:
+  - `--review required` or omitted → `required`
+  - `--review inline` → `inline`
+  - `--review off`, `skip review`, or `without review` → `off`
 
 **Build task queue**:
 - Read tasks.md, identify actionable sub-tasks (X.Y numbering like 1.1, 2.3)
@@ -97,23 +106,33 @@ If multi-agent capability is available, for each task (one at a time):
 - **BLOCKED** → dispatch debug subagent (see section below); do NOT immediately skip
 - **NEEDS_CONTEXT** → re-dispatch once with the requested additional context; if still unresolved → dispatch debug subagent
 
-**c) Dispatch reviewer**:
-- Read `templates/reviewer-prompt.md` from this skill's directory
-- Construct a review prompt with:
-  - The task description and relevant spec section numbers
-  - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
-  - The implementer's status report (for reference only — reviewer must verify independently)
-- The reviewer must apply the `kiro-review` protocol to this task-local review.
-- Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
-- The reviewer sub-agent will run `git diff` itself to read the actual code changes and verify against the spec
-- Spawn a fresh sub-agent with this prompt
+**c) Review the task**:
+- If review mode is `required`:
+  - Read `templates/reviewer-prompt.md` from this skill's directory
+  - Construct a review prompt with:
+    - The task description and relevant spec section numbers
+    - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
+    - The implementer's status report (for reference only — reviewer must verify independently)
+  - The reviewer must apply the `kiro-review` protocol to this task-local review.
+  - Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
+  - The reviewer sub-agent will run `git diff` itself to read the actual code changes and verify against the spec
+  - Spawn a fresh sub-agent with this prompt
+- If review mode is `inline`:
+  - Apply `kiro-review` in the parent context using the same task evidence and the actual `git diff`
+- If review mode is `off`:
+  - Skip task-local review
+  - Record in the parent context that task-local review was skipped for this task
 
 **d) Handle reviewer verdict**:
-- Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
-- If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
-- **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
-- **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
-- **REJECTED (round 3)** → dispatch debug subagent (see section below)
+- If review mode is `off`:
+  - Do not fabricate a reviewer verdict
+  - Before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+- Otherwise:
+  - Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
+  - If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
+  - **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+  - **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
+  - **REJECTED (round 3)** → dispatch debug subagent (see section below)
 
 **e) Commit** (parent-only, selective staging):
 - Stage only the files actually changed for this task, plus tasks.md
@@ -169,8 +188,13 @@ Before writing any code, read the relevant sections of requirements.md and desig
 - **GREEN**: Implement simplest solution to make test pass, following the design constraints.
 - **REFACTOR**: Improve code structure, remove duplication. All tests must still pass.
 - **VERIFY**: All tests pass (new and existing), no regressions. Confirm verification method passes.
-- **REVIEW**: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
-- **MARK COMPLETE**: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+- **REVIEW**:
+  - `required`: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
+  - `inline`: Apply `kiro-review` in the main context before marking the task complete.
+  - `off`: Skip task-local review, but note that `kiro-validate-impl` becomes the primary quality gate before any feature-level completion claim.
+- **MARK COMPLETE**:
+  - `required|inline`: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+  - `off`: Apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
 
 ## Step 4: Final Validation
 
@@ -184,6 +208,7 @@ Before writing any code, read the relevant sections of requirements.md and desig
 
 **Manual mode**:
 - Suggest running `/kiro-validate-impl $1` but do not auto-execute
+- If review mode is `off`, treat `/kiro-validate-impl $1` as mandatory before any feature-level success claim
 
 ## Feature Flag Protocol
 

--- a/tools/cc-sdd/templates/agents/gemini-cli-skills/skills/kiro-validate-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/gemini-cli-skills/skills/kiro-validate-impl/SKILL.md
@@ -7,7 +7,7 @@ description: Validate feature-level integration after all tasks are implemented.
 # Implementation Integration Validation
 
 <background_information>
-Individual tasks have already been reviewed by the per-task reviewer during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
+Individual tasks are usually reviewed during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
 
 Boundary terminology continuity:
 - discovery identifies `Boundary Candidates`
@@ -23,7 +23,7 @@ Boundary terminology continuity:
   - Design structure is reflected end-to-end (not just per-component)
   - No orphaned code, conflicting implementations, integration seams, or boundary spillover
 
-**What This Skill Does NOT Do**: Per-task checks are the reviewer's responsibility during `/kiro-impl`. This skill does NOT re-check individual task acceptance criteria, per-file reality checks, or single-task spec alignment.
+**What This Skill Does NOT Do**: This skill is not a full replacement for task-local review during `/kiro-impl`. This skill does NOT re-check every individual task acceptance criterion, every per-file reality check, or every single-task spec detail unless a concrete integration finding forces it.
 
 This skill's main question is: when the completed tasks are viewed together, do they still respect the designed boundary seams and dependency direction?
 </background_information>
@@ -60,6 +60,8 @@ The following validation dimensions are independent and can be dispatched as **s
 If multi-agent is not available, run checks sequentially in main context.
 
 After all checks complete, synthesize findings for GO/NO-GO/MANUAL_VERIFY_REQUIRED assessment.
+
+If the implementation run explicitly skipped task-local review (for example `--review off`), tighten scrutiny on obvious task-level gaps that surface during integration validation and call out that reduced review coverage in the report.
 
 ### 2. Load Context
 

--- a/tools/cc-sdd/templates/agents/github-copilot-skills/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/github-copilot-skills/docs/AGENTS.md
@@ -39,9 +39,10 @@ Project memory keeps persistent guidance (steering, specs notes, component docs)
     - `/kiro-validate-design {feature}` (optional: design review)
     - `/kiro-spec-tasks {feature} [-y]`
   - Multi-spec: `/kiro-spec-batch` — creates all specs from roadmap.md in parallel by dependency wave
-- Phase 2 (Implementation): `/kiro-impl {feature} [tasks]`
+- Phase 2 (Implementation): `/kiro-impl {feature} [tasks] [--review required|inline|off]`
   - Without task numbers: autonomous mode (subagent per task + independent review + final validation)
   - With task numbers: manual mode (selected tasks in main context, still reviewer-gated before completion)
+  - `--review off` skips task-local review; use it intentionally and keep `/kiro-validate-impl {feature}` as the final quality gate
   - `/kiro-validate-impl {feature}` (standalone re-validation)
 - Progress check: `/kiro-spec-status {feature}` (use anytime)
 

--- a/tools/cc-sdd/templates/agents/github-copilot-skills/skills/kiro-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/github-copilot-skills/skills/kiro-impl/SKILL.md
@@ -16,7 +16,12 @@ You operate in two modes:
   - Code passes all tests with no regressions
   - Tasks marked as completed in tasks.md
   - Implementation aligns with design and requirements
-  - Independent reviewer approves each task before completion
+  - Task completion follows the selected review mode
+- **Review Mode**:
+  - Default is `required`
+  - Accept explicit forms: `--review required|inline|off`
+  - Also accept clear natural-language opt-outs such as `skip review` or `without review` as `off`
+  - If the request is ambiguous, keep `required`
 </background_information>
 
 <instructions>
@@ -59,6 +64,10 @@ After all parallel research completes, synthesize implementation brief before st
 - Extract feature name from `$1`
 - If task numbers provided in `$2` (e.g., "1.1" or "1,2,3"): **manual mode**
 - If no task numbers: **autonomous mode** (all pending tasks)
+- Determine review mode from the invocation:
+  - `--review required` or omitted → `required`
+  - `--review inline` → `inline`
+  - `--review off`, `skip review`, or `without review` → `off`
 
 **Build task queue**:
 - Read tasks.md, identify actionable sub-tasks (X.Y numbering like 1.1, 2.3)
@@ -97,23 +106,33 @@ If multi-agent capability is available, for each task (one at a time):
 - **BLOCKED** → dispatch debug subagent (see section below); do NOT immediately skip
 - **NEEDS_CONTEXT** → re-dispatch once with the requested additional context; if still unresolved → dispatch debug subagent
 
-**c) Dispatch reviewer**:
-- Read `templates/reviewer-prompt.md` from this skill's directory
-- Construct a review prompt with:
-  - The task description and relevant spec section numbers
-  - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
-  - The implementer's status report (for reference only — reviewer must verify independently)
-- The reviewer must apply the `kiro-review` protocol to this task-local review.
-- Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
-- The reviewer sub-agent will run `git diff` itself to read the actual code changes and verify against the spec
-- Spawn a fresh sub-agent with this prompt
+**c) Review the task**:
+- If review mode is `required`:
+  - Read `templates/reviewer-prompt.md` from this skill's directory
+  - Construct a review prompt with:
+    - The task description and relevant spec section numbers
+    - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
+    - The implementer's status report (for reference only — reviewer must verify independently)
+  - The reviewer must apply the `kiro-review` protocol to this task-local review.
+  - Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
+  - The reviewer sub-agent will run `git diff` itself to read the actual code changes and verify against the spec
+  - Spawn a fresh sub-agent with this prompt
+- If review mode is `inline`:
+  - Apply `kiro-review` in the parent context using the same task evidence and the actual `git diff`
+- If review mode is `off`:
+  - Skip task-local review
+  - Record in the parent context that task-local review was skipped for this task
 
 **d) Handle reviewer verdict**:
-- Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
-- If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
-- **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
-- **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
-- **REJECTED (round 3)** → dispatch debug subagent (see section below)
+- If review mode is `off`:
+  - Do not fabricate a reviewer verdict
+  - Before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+- Otherwise:
+  - Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
+  - If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
+  - **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+  - **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
+  - **REJECTED (round 3)** → dispatch debug subagent (see section below)
 
 **e) Commit** (parent-only, selective staging):
 - Stage only the files actually changed for this task, plus tasks.md
@@ -169,8 +188,13 @@ Before writing any code, read the relevant sections of requirements.md and desig
 - **GREEN**: Implement simplest solution to make test pass, following the design constraints.
 - **REFACTOR**: Improve code structure, remove duplication. All tests must still pass.
 - **VERIFY**: All tests pass (new and existing), no regressions. Confirm verification method passes.
-- **REVIEW**: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
-- **MARK COMPLETE**: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+- **REVIEW**:
+  - `required`: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
+  - `inline`: Apply `kiro-review` in the main context before marking the task complete.
+  - `off`: Skip task-local review, but note that `kiro-validate-impl` becomes the primary quality gate before any feature-level completion claim.
+- **MARK COMPLETE**:
+  - `required|inline`: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+  - `off`: Apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
 
 ## Step 4: Final Validation
 
@@ -184,6 +208,7 @@ Before writing any code, read the relevant sections of requirements.md and desig
 
 **Manual mode**:
 - Suggest running `/kiro-validate-impl $1` but do not auto-execute
+- If review mode is `off`, treat `/kiro-validate-impl $1` as mandatory before any feature-level success claim
 
 ## Feature Flag Protocol
 

--- a/tools/cc-sdd/templates/agents/github-copilot-skills/skills/kiro-validate-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/github-copilot-skills/skills/kiro-validate-impl/SKILL.md
@@ -7,7 +7,7 @@ description: Validate feature-level integration after all tasks are implemented.
 # Implementation Integration Validation
 
 <background_information>
-Individual tasks have already been reviewed by the per-task reviewer during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
+Individual tasks are usually reviewed during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
 
 Boundary terminology continuity:
 - discovery identifies `Boundary Candidates`
@@ -23,7 +23,7 @@ Boundary terminology continuity:
   - Design structure is reflected end-to-end (not just per-component)
   - No orphaned code, conflicting implementations, integration seams, or boundary spillover
 
-**What This Skill Does NOT Do**: Per-task checks are the reviewer's responsibility during `/kiro-impl`. This skill does NOT re-check individual task acceptance criteria, per-file reality checks, or single-task spec alignment.
+**What This Skill Does NOT Do**: This skill is not a full replacement for task-local review during `/kiro-impl`. This skill does NOT re-check every individual task acceptance criterion, every per-file reality check, or every single-task spec detail unless a concrete integration finding forces it.
 
 This skill's main question is: when the completed tasks are viewed together, do they still respect the designed boundary seams and dependency direction?
 </background_information>
@@ -60,6 +60,8 @@ The following validation dimensions are independent and can be dispatched as **s
 If multi-agent is not available, run checks sequentially in main context.
 
 After all checks complete, synthesize findings for GO/NO-GO/MANUAL_VERIFY_REQUIRED assessment.
+
+If the implementation run explicitly skipped task-local review (for example `--review off`), tighten scrutiny on obvious task-level gaps that surface during integration validation and call out that reduced review coverage in the report.
 
 ### 2. Load Context
 

--- a/tools/cc-sdd/templates/agents/opencode-skills/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/opencode-skills/docs/AGENTS.md
@@ -39,9 +39,10 @@ Project memory keeps persistent guidance (steering, specs notes, component docs)
     - `/kiro-validate-design {feature}` (optional: design review)
     - `/kiro-spec-tasks {feature} [-y]`
   - Multi-spec: `/kiro-spec-batch` — creates all specs from roadmap.md in parallel by dependency wave
-- Phase 2 (Implementation): `/kiro-impl {feature} [tasks]`
+- Phase 2 (Implementation): `/kiro-impl {feature} [tasks] [--review required|inline|off]`
   - Without task numbers: autonomous mode (subagent per task + independent review + final validation)
   - With task numbers: manual mode (selected tasks in main context, still reviewer-gated before completion)
+  - `--review off` skips task-local review; use it intentionally and keep `/kiro-validate-impl {feature}` as the final quality gate
   - `/kiro-validate-impl {feature}` (standalone re-validation)
 - Progress check: `/kiro-spec-status {feature}` (use anytime)
 

--- a/tools/cc-sdd/templates/agents/opencode-skills/skills/kiro-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/opencode-skills/skills/kiro-impl/SKILL.md
@@ -16,7 +16,12 @@ You operate in two modes:
   - Code passes all tests with no regressions
   - Tasks marked as completed in tasks.md
   - Implementation aligns with design and requirements
-  - Independent reviewer approves each task before completion
+  - Task completion follows the selected review mode
+- **Review Mode**:
+  - Default is `required`
+  - Accept explicit forms: `--review required|inline|off`
+  - Also accept clear natural-language opt-outs such as `skip review` or `without review` as `off`
+  - If the request is ambiguous, keep `required`
 </background_information>
 
 <instructions>
@@ -59,6 +64,10 @@ After all parallel research completes, synthesize implementation brief before st
 - Extract feature name from `$1`
 - If task numbers provided in `$2` (e.g., "1.1" or "1,2,3"): **manual mode**
 - If no task numbers: **autonomous mode** (all pending tasks)
+- Determine review mode from the invocation:
+  - `--review required` or omitted → `required`
+  - `--review inline` → `inline`
+  - `--review off`, `skip review`, or `without review` → `off`
 
 **Build task queue**:
 - Read tasks.md, identify actionable sub-tasks (X.Y numbering like 1.1, 2.3)
@@ -97,23 +106,33 @@ If multi-agent capability is available, for each task (one at a time):
 - **BLOCKED** → dispatch debug subagent (see section below); do NOT immediately skip
 - **NEEDS_CONTEXT** → re-dispatch once with the requested additional context; if still unresolved → dispatch debug subagent
 
-**c) Dispatch reviewer**:
-- Read `templates/reviewer-prompt.md` from this skill's directory
-- Construct a review prompt with:
-  - The task description and relevant spec section numbers
-  - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
-  - The implementer's status report (for reference only — reviewer must verify independently)
-- The reviewer must apply the `kiro-review` protocol to this task-local review.
-- Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
-- The reviewer sub-agent will run `git diff` itself to read the actual code changes and verify against the spec
-- Spawn a fresh sub-agent with this prompt
+**c) Review the task**:
+- If review mode is `required`:
+  - Read `templates/reviewer-prompt.md` from this skill's directory
+  - Construct a review prompt with:
+    - The task description and relevant spec section numbers
+    - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
+    - The implementer's status report (for reference only — reviewer must verify independently)
+  - The reviewer must apply the `kiro-review` protocol to this task-local review.
+  - Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
+  - The reviewer sub-agent will run `git diff` itself to read the actual code changes and verify against the spec
+  - Spawn a fresh sub-agent with this prompt
+- If review mode is `inline`:
+  - Apply `kiro-review` in the parent context using the same task evidence and the actual `git diff`
+- If review mode is `off`:
+  - Skip task-local review
+  - Record in the parent context that task-local review was skipped for this task
 
 **d) Handle reviewer verdict**:
-- Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
-- If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
-- **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
-- **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
-- **REJECTED (round 3)** → dispatch debug subagent (see section below)
+- If review mode is `off`:
+  - Do not fabricate a reviewer verdict
+  - Before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+- Otherwise:
+  - Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
+  - If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
+  - **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+  - **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
+  - **REJECTED (round 3)** → dispatch debug subagent (see section below)
 
 **e) Commit** (parent-only, selective staging):
 - Stage only the files actually changed for this task, plus tasks.md
@@ -169,8 +188,13 @@ Before writing any code, read the relevant sections of requirements.md and desig
 - **GREEN**: Implement simplest solution to make test pass, following the design constraints.
 - **REFACTOR**: Improve code structure, remove duplication. All tests must still pass.
 - **VERIFY**: All tests pass (new and existing), no regressions. Confirm verification method passes.
-- **REVIEW**: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
-- **MARK COMPLETE**: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+- **REVIEW**:
+  - `required`: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
+  - `inline`: Apply `kiro-review` in the main context before marking the task complete.
+  - `off`: Skip task-local review, but note that `kiro-validate-impl` becomes the primary quality gate before any feature-level completion claim.
+- **MARK COMPLETE**:
+  - `required|inline`: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+  - `off`: Apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
 
 ## Step 4: Final Validation
 
@@ -184,6 +208,7 @@ Before writing any code, read the relevant sections of requirements.md and desig
 
 **Manual mode**:
 - Suggest running `/kiro-validate-impl $1` but do not auto-execute
+- If review mode is `off`, treat `/kiro-validate-impl $1` as mandatory before any feature-level success claim
 
 ## Feature Flag Protocol
 

--- a/tools/cc-sdd/templates/agents/opencode-skills/skills/kiro-validate-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/opencode-skills/skills/kiro-validate-impl/SKILL.md
@@ -7,7 +7,7 @@ description: Validate feature-level integration after all tasks are implemented.
 # Implementation Integration Validation
 
 <background_information>
-Individual tasks have already been reviewed by the per-task reviewer during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
+Individual tasks are usually reviewed during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
 
 Boundary terminology continuity:
 - discovery identifies `Boundary Candidates`
@@ -23,7 +23,7 @@ Boundary terminology continuity:
   - Design structure is reflected end-to-end (not just per-component)
   - No orphaned code, conflicting implementations, integration seams, or boundary spillover
 
-**What This Skill Does NOT Do**: Per-task checks are the reviewer's responsibility during `/kiro-impl`. This skill does NOT re-check individual task acceptance criteria, per-file reality checks, or single-task spec alignment.
+**What This Skill Does NOT Do**: This skill is not a full replacement for task-local review during `/kiro-impl`. This skill does NOT re-check every individual task acceptance criterion, every per-file reality check, or every single-task spec detail unless a concrete integration finding forces it.
 
 This skill's main question is: when the completed tasks are viewed together, do they still respect the designed boundary seams and dependency direction?
 </background_information>
@@ -60,6 +60,8 @@ The following validation dimensions are independent and can be dispatched as **s
 If multi-agent is not available, run checks sequentially in main context.
 
 After all checks complete, synthesize findings for GO/NO-GO/MANUAL_VERIFY_REQUIRED assessment.
+
+If the implementation run explicitly skipped task-local review (for example `--review off`), tighten scrutiny on obvious task-level gaps that surface during integration validation and call out that reduced review coverage in the report.
 
 ### 2. Load Context
 

--- a/tools/cc-sdd/templates/agents/windsurf-skills/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/windsurf-skills/docs/AGENTS.md
@@ -39,9 +39,10 @@ Project memory keeps persistent guidance (steering, specs notes, component docs)
     - `@kiro-validate-design {feature}` (optional: design review)
     - `@kiro-spec-tasks {feature} [-y]`
   - Multi-spec: `@kiro-spec-batch` — creates all specs from roadmap.md in parallel by dependency wave
-- Phase 2 (Implementation): `@kiro-impl {feature} [tasks]`
+- Phase 2 (Implementation): `@kiro-impl {feature} [tasks] [--review required|inline|off]`
   - Without task numbers: autonomous mode (subagent per task + independent review + final validation)
   - With task numbers: manual mode (selected tasks in main context, still reviewer-gated before completion)
+  - `--review off` skips task-local review; use it intentionally and keep `@kiro-validate-impl {feature}` as the final quality gate
   - `@kiro-validate-impl {feature}` (standalone re-validation)
 - Progress check: `@kiro-spec-status {feature}` (use anytime)
 

--- a/tools/cc-sdd/templates/agents/windsurf-skills/skills/kiro-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/windsurf-skills/skills/kiro-impl/SKILL.md
@@ -16,7 +16,12 @@ You operate in two modes:
   - Code passes all tests with no regressions
   - Tasks marked as completed in tasks.md
   - Implementation aligns with design and requirements
-  - Independent reviewer approves each task before completion
+  - Task completion follows the selected review mode
+- **Review Mode**:
+  - Default is `required`
+  - Accept explicit forms: `--review required|inline|off`
+  - Also accept clear natural-language opt-outs such as `skip review` or `without review` as `off`
+  - If the request is ambiguous, keep `required`
 </background_information>
 
 <instructions>
@@ -59,6 +64,10 @@ After all parallel research completes, synthesize implementation brief before st
 - Extract feature name from `$1`
 - If task numbers provided in `$2` (e.g., "1.1" or "1,2,3"): **manual mode**
 - If no task numbers: **autonomous mode** (all pending tasks)
+- Determine review mode from the invocation:
+  - `--review required` or omitted → `required`
+  - `--review inline` → `inline`
+  - `--review off`, `skip review`, or `without review` → `off`
 
 **Build task queue**:
 - Read tasks.md, identify actionable sub-tasks (X.Y numbering like 1.1, 2.3)
@@ -97,23 +106,33 @@ If multi-agent capability is available, for each task (one at a time):
 - **BLOCKED** → dispatch debug subagent (see section below); do NOT immediately skip
 - **NEEDS_CONTEXT** → re-dispatch once with the requested additional context; if still unresolved → dispatch debug subagent
 
-**c) Dispatch reviewer**:
-- Read `templates/reviewer-prompt.md` from this skill's directory
-- Construct a review prompt with:
-  - The task description and relevant spec section numbers
-  - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
-  - The implementer's status report (for reference only — reviewer must verify independently)
-- The reviewer must apply the `kiro-review` protocol to this task-local review.
-- Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
-- The reviewer sub-agent will run `git diff` itself to read the actual code changes and verify against the spec
-- Spawn a fresh sub-agent with this prompt
+**c) Review the task**:
+- If review mode is `required`:
+  - Read `templates/reviewer-prompt.md` from this skill's directory
+  - Construct a review prompt with:
+    - The task description and relevant spec section numbers
+    - Paths to spec files (requirements.md, design.md) so the reviewer can read them directly
+    - The implementer's status report (for reference only — reviewer must verify independently)
+  - The reviewer must apply the `kiro-review` protocol to this task-local review.
+  - Preserve the existing task-specific context: task text, spec refs, `_Boundary:_` scope, validation commands, implementer report, and the actual `git diff` as the primary source of truth.
+  - The reviewer sub-agent will run `git diff` itself to read the actual code changes and verify against the spec
+  - Spawn a fresh sub-agent with this prompt
+- If review mode is `inline`:
+  - Apply `kiro-review` in the parent context using the same task evidence and the actual `git diff`
+- If review mode is `off`:
+  - Skip task-local review
+  - Record in the parent context that task-local review was skipped for this task
 
 **d) Handle reviewer verdict**:
-- Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
-- If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
-- **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
-- **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
-- **REJECTED (round 3)** → dispatch debug subagent (see section below)
+- If review mode is `off`:
+  - Do not fabricate a reviewer verdict
+  - Before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+- Otherwise:
+  - Parse reviewer verdict only from the exact `## Review Verdict` block and `- VERDICT:` field.
+  - If `VERDICT` is missing, ambiguous, or replaced with prose, re-dispatch the reviewer once requesting the exact structured verdict only. Do NOT mark the task complete, commit, or continue to the next task without a parseable `APPROVED | REJECTED` value.
+  - **APPROVED** → before marking the task `[x]` or making any success claim, apply `kiro-verify-completion` using fresh evidence from the current code state; then mark task `[x]` in tasks.md and perform selective git commit
+  - **REJECTED (round 1-2)** → re-dispatch implementer with review feedback
+  - **REJECTED (round 3)** → dispatch debug subagent (see section below)
 
 **e) Commit** (parent-only, selective staging):
 - Stage only the files actually changed for this task, plus tasks.md
@@ -169,8 +188,13 @@ Before writing any code, read the relevant sections of requirements.md and desig
 - **GREEN**: Implement simplest solution to make test pass, following the design constraints.
 - **REFACTOR**: Improve code structure, remove duplication. All tests must still pass.
 - **VERIFY**: All tests pass (new and existing), no regressions. Confirm verification method passes.
-- **REVIEW**: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
-- **MARK COMPLETE**: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+- **REVIEW**:
+  - `required`: Apply `kiro-review` before marking the task complete. If the host supports fresh subagents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
+  - `inline`: Apply `kiro-review` in the main context before marking the task complete.
+  - `off`: Skip task-local review, but note that `kiro-validate-impl` becomes the primary quality gate before any feature-level completion claim.
+- **MARK COMPLETE**:
+  - `required|inline`: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
+  - `off`: Apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
 
 ## Step 4: Final Validation
 
@@ -184,6 +208,7 @@ Before writing any code, read the relevant sections of requirements.md and desig
 
 **Manual mode**:
 - Suggest running `@kiro-validate-impl $1` but do not auto-execute
+- If review mode is `off`, treat `@kiro-validate-impl $1` as mandatory before any feature-level success claim
 
 ## Feature Flag Protocol
 

--- a/tools/cc-sdd/templates/agents/windsurf-skills/skills/kiro-validate-impl/SKILL.md
+++ b/tools/cc-sdd/templates/agents/windsurf-skills/skills/kiro-validate-impl/SKILL.md
@@ -7,7 +7,7 @@ description: Validate feature-level integration after all tasks are implemented.
 # Implementation Integration Validation
 
 <background_information>
-Individual tasks have already been reviewed by the per-task reviewer during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
+Individual tasks are usually reviewed during implementation. Your job is to catch problems that only become visible when looking across all tasks together.
 
 Boundary terminology continuity:
 - discovery identifies `Boundary Candidates`
@@ -23,7 +23,7 @@ Boundary terminology continuity:
   - Design structure is reflected end-to-end (not just per-component)
   - No orphaned code, conflicting implementations, integration seams, or boundary spillover
 
-**What This Skill Does NOT Do**: Per-task checks are the reviewer's responsibility during `@kiro-impl`. This skill does NOT re-check individual task acceptance criteria, per-file reality checks, or single-task spec alignment.
+**What This Skill Does NOT Do**: This skill is not a full replacement for task-local review during `@kiro-impl`. This skill does NOT re-check every individual task acceptance criterion, every per-file reality check, or every single-task spec detail unless a concrete integration finding forces it.
 
 This skill's main question is: when the completed tasks are viewed together, do they still respect the designed boundary seams and dependency direction?
 </background_information>
@@ -60,6 +60,8 @@ The following validation dimensions are independent and can be dispatched as **s
 If multi-agent is not available, run checks sequentially in main context.
 
 After all checks complete, synthesize findings for GO/NO-GO/MANUAL_VERIFY_REQUIRED assessment.
+
+If the implementation run explicitly skipped task-local review (for example `--review off`), tighten scrutiny on obvious task-level gaps that surface during integration validation and call out that reduced review coverage in the report.
 
 ### 2. Load Context
 

--- a/tools/cc-sdd/test/realManifestAntigravitySkills.test.ts
+++ b/tools/cc-sdd/test/realManifestAntigravitySkills.test.ts
@@ -74,6 +74,8 @@ describe('real antigravity-skills manifest', () => {
     expect(docText).toContain('/kiro-spec-status');
     expect(docText).not.toContain('$kiro-spec-status');
     expect(docText).toContain('autonomous mode');
+    expect(docText).toContain('[--review required|inline|off]');
+    expect(docText).toContain('`--review off` skips task-local review');
 
     const skillSpecInit = join(cwd, '.agent/skills/kiro-spec-init/SKILL.md');
     expect(await exists(skillSpecInit)).toBe(true);
@@ -110,6 +112,16 @@ describe('real antigravity-skills manifest', () => {
     expect(skillValidateImplText).toContain('Core steering context: `product.md`, `tech.md`, `structure.md`');
     expect(skillValidateImplText).toContain('MANUAL_VERIFY_REQUIRED');
     expect(skillValidateImplText).toContain('Does NOT Do');
+    expect(skillValidateImplText).toContain('usually reviewed during implementation');
+    expect(skillValidateImplText).toContain('`--review off`');
+
+    const skillImpl = join(cwd, '.agent/skills/kiro-impl/SKILL.md');
+    expect(await exists(skillImpl)).toBe(true);
+    const skillImplText = await readFile(skillImpl, 'utf8');
+    expect(skillImplText).toContain('Default is `required`');
+    expect(skillImplText).toContain('`--review required|inline|off`');
+    expect(skillImplText).toContain('skip review');
+    expect(skillImplText).toContain('If review mode is `off`');
 
     const skillValidateDesign = join(cwd, '.agent/skills/kiro-validate-design/SKILL.md');
     expect(await exists(skillValidateDesign)).toBe(true);

--- a/tools/cc-sdd/test/realManifestClaudeCodeSkills.test.ts
+++ b/tools/cc-sdd/test/realManifestClaudeCodeSkills.test.ts
@@ -56,6 +56,8 @@ describe('real claude-code-skills manifest', () => {
     expect(text).toContain('/kiro-spec-status');
     expect(text).not.toContain('/kiro:spec-status');
     expect(text).toContain('autonomous mode');
+    expect(text).toContain('[--review required|inline|off]');
+    expect(text).toContain('`--review off` skips task-local review');
 
     const skillSpecInit = join(cwd, '.claude/skills/kiro-spec-init/SKILL.md');
     expect(await exists(skillSpecInit)).toBe(true);
@@ -83,6 +85,8 @@ describe('real claude-code-skills manifest', () => {
     expect(skillValidateImplText).toContain('Core steering context: `product.md`, `tech.md`, `structure.md`');
     expect(skillValidateImplText).toContain('MANUAL_VERIFY_REQUIRED');
     expect(skillValidateImplText).toContain('Does NOT Do');
+    expect(skillValidateImplText).toContain('usually reviewed during implementation');
+    expect(skillValidateImplText).toContain('`--review off`');
 
     const skillValidateDesign = join(cwd, '.claude/skills/kiro-validate-design/SKILL.md');
     expect(await exists(skillValidateDesign)).toBe(true);
@@ -123,6 +127,10 @@ describe('real claude-code-skills manifest', () => {
     expect(skillImplText).toContain('No Destructive Reset');
     expect(skillImplText).toContain('stop the feature run');
     expect(skillImplText).not.toContain('discard the failed implementation (`git checkout .`)');
+    expect(skillImplText).toContain('argument-hint: <feature-name> [task-numbers] [--review required|inline|off]');
+    expect(skillImplText).toContain('Default review mode is `required`');
+    expect(skillImplText).toContain('skip review');
+    expect(skillImplText).toContain('If review mode is `off`');
 
     const implPrompt = join(cwd, '.claude/skills/kiro-impl/templates/implementer-prompt.md');
     expect(await exists(implPrompt)).toBe(true);

--- a/tools/cc-sdd/test/realManifestCodexSkills.test.ts
+++ b/tools/cc-sdd/test/realManifestCodexSkills.test.ts
@@ -74,6 +74,8 @@ describe('real codex-skills manifest', () => {
     expect(docText).toContain('$kiro-spec-status');
     expect(docText).not.toContain('/prompts:kiro-spec-status');
     expect(docText).toContain('autonomous mode');
+    expect(docText).toContain('[--review required|inline|off]');
+    expect(docText).toContain('`--review off` skips task-local review');
 
     const skillSpecInit = join(cwd, '.agents/skills/kiro-spec-init/SKILL.md');
     expect(await exists(skillSpecInit)).toBe(true);
@@ -111,6 +113,8 @@ describe('real codex-skills manifest', () => {
     expect(skillValidateImplText).toContain('MANUAL_VERIFY_REQUIRED');
     expect(skillValidateImplText).toContain('Does NOT Do');
     expect(skillValidateImplText).toContain('kiro-verify-completion');
+    expect(skillValidateImplText).toContain('usually reviewed during implementation');
+    expect(skillValidateImplText).toContain('`--review off`');
 
     const skillImpl = join(cwd, '.agents/skills/kiro-impl/SKILL.md');
     expect(await exists(skillImpl)).toBe(true);
@@ -118,6 +122,10 @@ describe('real codex-skills manifest', () => {
     expect(skillImplText).toContain('No Destructive Reset');
     expect(skillImplText).toContain('stop the feature run');
     expect(skillImplText).not.toContain('discard the failed implementation (`git checkout .`)');
+    expect(skillImplText).toContain('Default is `required`');
+    expect(skillImplText).toContain('`--review required|inline|off`');
+    expect(skillImplText).toContain('skip review');
+    expect(skillImplText).toContain('If review mode is `off`');
 
     const skillValidateDesign = join(cwd, '.agents/skills/kiro-validate-design/SKILL.md');
     expect(await exists(skillValidateDesign)).toBe(true);

--- a/tools/cc-sdd/test/realManifestCursorSkills.test.ts
+++ b/tools/cc-sdd/test/realManifestCursorSkills.test.ts
@@ -74,6 +74,8 @@ describe('real cursor-skills manifest', () => {
     expect(docText).toContain('/kiro-spec-status');
     expect(docText).not.toContain('$kiro-spec-status');
     expect(docText).toContain('autonomous mode');
+    expect(docText).toContain('[--review required|inline|off]');
+    expect(docText).toContain('`--review off` skips task-local review');
 
     const skillSpecInit = join(cwd, '.cursor/skills/kiro-spec-init/SKILL.md');
     expect(await exists(skillSpecInit)).toBe(true);
@@ -110,6 +112,16 @@ describe('real cursor-skills manifest', () => {
     expect(skillValidateImplText).toContain('Core steering context: `product.md`, `tech.md`, `structure.md`');
     expect(skillValidateImplText).toContain('MANUAL_VERIFY_REQUIRED');
     expect(skillValidateImplText).toContain('Does NOT Do');
+    expect(skillValidateImplText).toContain('usually reviewed during implementation');
+    expect(skillValidateImplText).toContain('`--review off`');
+
+    const skillImpl = join(cwd, '.cursor/skills/kiro-impl/SKILL.md');
+    expect(await exists(skillImpl)).toBe(true);
+    const skillImplText = await readFile(skillImpl, 'utf8');
+    expect(skillImplText).toContain('Default is `required`');
+    expect(skillImplText).toContain('`--review required|inline|off`');
+    expect(skillImplText).toContain('skip review');
+    expect(skillImplText).toContain('If review mode is `off`');
 
     const skillValidateDesign = join(cwd, '.cursor/skills/kiro-validate-design/SKILL.md');
     expect(await exists(skillValidateDesign)).toBe(true);

--- a/tools/cc-sdd/test/realManifestGeminiCliSkills.test.ts
+++ b/tools/cc-sdd/test/realManifestGeminiCliSkills.test.ts
@@ -75,6 +75,8 @@ describe('real gemini-cli-skills manifest', () => {
     expect(docText).toContain('/kiro-spec-status');
     expect(docText).not.toContain('$kiro-spec-status');
     expect(docText).toContain('autonomous mode');
+    expect(docText).toContain('[--review required|inline|off]');
+    expect(docText).toContain('`--review off` skips task-local review');
 
     const skillSpecInit = join(cwd, '.gemini/skills/kiro-spec-init/SKILL.md');
     expect(await exists(skillSpecInit)).toBe(true);
@@ -115,6 +117,16 @@ describe('real gemini-cli-skills manifest', () => {
     expect(skillValidateImplText).toContain('Core steering context: `product.md`, `tech.md`, `structure.md`');
     expect(skillValidateImplText).toContain('MANUAL_VERIFY_REQUIRED');
     expect(skillValidateImplText).toContain('Does NOT Do');
+    expect(skillValidateImplText).toContain('usually reviewed during implementation');
+    expect(skillValidateImplText).toContain('`--review off`');
+
+    const skillImpl = join(cwd, '.gemini/skills/kiro-impl/SKILL.md');
+    expect(await exists(skillImpl)).toBe(true);
+    const skillImplText = await readFile(skillImpl, 'utf8');
+    expect(skillImplText).toContain('Default is `required`');
+    expect(skillImplText).toContain('`--review required|inline|off`');
+    expect(skillImplText).toContain('skip review');
+    expect(skillImplText).toContain('If review mode is `off`');
 
     const skillValidateDesign = join(cwd, '.gemini/skills/kiro-validate-design/SKILL.md');
     expect(await exists(skillValidateDesign)).toBe(true);

--- a/tools/cc-sdd/test/realManifestGithubCopilotSkills.test.ts
+++ b/tools/cc-sdd/test/realManifestGithubCopilotSkills.test.ts
@@ -74,6 +74,8 @@ describe('real github-copilot-skills manifest', () => {
     expect(docText).toContain('/kiro-spec-status');
     expect(docText).not.toContain('$kiro-spec-status');
     expect(docText).toContain('autonomous mode');
+    expect(docText).toContain('[--review required|inline|off]');
+    expect(docText).toContain('`--review off` skips task-local review');
 
     const skillSpecInit = join(cwd, '.github/skills/kiro-spec-init/SKILL.md');
     expect(await exists(skillSpecInit)).toBe(true);
@@ -110,6 +112,16 @@ describe('real github-copilot-skills manifest', () => {
     expect(skillValidateImplText).toContain('Core steering context: `product.md`, `tech.md`, `structure.md`');
     expect(skillValidateImplText).toContain('MANUAL_VERIFY_REQUIRED');
     expect(skillValidateImplText).toContain('Does NOT Do');
+    expect(skillValidateImplText).toContain('usually reviewed during implementation');
+    expect(skillValidateImplText).toContain('`--review off`');
+
+    const skillImpl = join(cwd, '.github/skills/kiro-impl/SKILL.md');
+    expect(await exists(skillImpl)).toBe(true);
+    const skillImplText = await readFile(skillImpl, 'utf8');
+    expect(skillImplText).toContain('Default is `required`');
+    expect(skillImplText).toContain('`--review required|inline|off`');
+    expect(skillImplText).toContain('skip review');
+    expect(skillImplText).toContain('If review mode is `off`');
 
     const skillValidateDesign = join(cwd, '.github/skills/kiro-validate-design/SKILL.md');
     expect(await exists(skillValidateDesign)).toBe(true);

--- a/tools/cc-sdd/test/realManifestOpencodeSkills.test.ts
+++ b/tools/cc-sdd/test/realManifestOpencodeSkills.test.ts
@@ -74,6 +74,8 @@ describe('real opencode-skills manifest', () => {
     expect(docText).toContain('/kiro-spec-status');
     expect(docText).not.toContain('$kiro-spec-status');
     expect(docText).toContain('autonomous mode');
+    expect(docText).toContain('[--review required|inline|off]');
+    expect(docText).toContain('`--review off` skips task-local review');
 
     const skillSpecInit = join(cwd, '.opencode/skills/kiro-spec-init/SKILL.md');
     expect(await exists(skillSpecInit)).toBe(true);
@@ -110,6 +112,16 @@ describe('real opencode-skills manifest', () => {
     expect(skillValidateImplText).toContain('Core steering context: `product.md`, `tech.md`, `structure.md`');
     expect(skillValidateImplText).toContain('MANUAL_VERIFY_REQUIRED');
     expect(skillValidateImplText).toContain('Does NOT Do');
+    expect(skillValidateImplText).toContain('usually reviewed during implementation');
+    expect(skillValidateImplText).toContain('`--review off`');
+
+    const skillImpl = join(cwd, '.opencode/skills/kiro-impl/SKILL.md');
+    expect(await exists(skillImpl)).toBe(true);
+    const skillImplText = await readFile(skillImpl, 'utf8');
+    expect(skillImplText).toContain('Default is `required`');
+    expect(skillImplText).toContain('`--review required|inline|off`');
+    expect(skillImplText).toContain('skip review');
+    expect(skillImplText).toContain('If review mode is `off`');
 
     const skillValidateDesign = join(cwd, '.opencode/skills/kiro-validate-design/SKILL.md');
     expect(await exists(skillValidateDesign)).toBe(true);

--- a/tools/cc-sdd/test/realManifestWindsurfSkills.test.ts
+++ b/tools/cc-sdd/test/realManifestWindsurfSkills.test.ts
@@ -75,6 +75,8 @@ describe('real windsurf-skills manifest', () => {
     expect(docText).not.toContain('$kiro-spec-status');
     expect(docText).not.toContain('/kiro-spec-status');
     expect(docText).toContain('autonomous mode');
+    expect(docText).toContain('[--review required|inline|off]');
+    expect(docText).toContain('`--review off` skips task-local review');
 
     const skillSpecInit = join(cwd, '.windsurf/skills/kiro-spec-init/SKILL.md');
     expect(await exists(skillSpecInit)).toBe(true);
@@ -111,6 +113,16 @@ describe('real windsurf-skills manifest', () => {
     expect(skillValidateImplText).toContain('Core steering context: `product.md`, `tech.md`, `structure.md`');
     expect(skillValidateImplText).toContain('MANUAL_VERIFY_REQUIRED');
     expect(skillValidateImplText).toContain('Does NOT Do');
+    expect(skillValidateImplText).toContain('usually reviewed during implementation');
+    expect(skillValidateImplText).toContain('`--review off`');
+
+    const skillImpl = join(cwd, '.windsurf/skills/kiro-impl/SKILL.md');
+    expect(await exists(skillImpl)).toBe(true);
+    const skillImplText = await readFile(skillImpl, 'utf8');
+    expect(skillImplText).toContain('Default is `required`');
+    expect(skillImplText).toContain('`--review required|inline|off`');
+    expect(skillImplText).toContain('skip review');
+    expect(skillImplText).toContain('If review mode is `off`');
 
     const skillValidateDesign = join(cwd, '.windsurf/skills/kiro-validate-design/SKILL.md');
     expect(await exists(skillValidateDesign)).toBe(true);


### PR DESCRIPTION
## Summary
- add `--review required|inline|off` support to all skills-based `kiro-impl` templates
- document the review mode behavior in each skills-agent doc and tighten `kiro-validate-impl` guidance when task-local review is skipped
- extend real-manifest tests across all affected skills-agent variants

## Validation
- `npx vitest run test/realManifestClaudeCodeSkills.test.ts test/realManifestCodexSkills.test.ts test/realManifestCursorSkills.test.ts test/realManifestGeminiCliSkills.test.ts test/realManifestWindsurfSkills.test.ts test/realManifestAntigravitySkills.test.ts test/realManifestOpencodeSkills.test.ts test/realManifestGithubCopilotSkills.test.ts`

## Review note
- accepted risk: natural-language review opt-out remains supported for operator ergonomics because equivalent model-mediated behavior already existed before this change; `kiro-verify-completion` and feature-level `kiro-validate-impl` remain the backstops