### PR TITLE
fix: replace non-existent tool names with correct Claude Code tool names in steering.md

### DIFF
--- a/tools/cc-sdd/templates/agents/claude-code/commands/steering.md
+++ b/tools/cc-sdd/templates/agents/claude-code/commands/steering.md
@@ -33,9 +33,9 @@ Check `{{KIRO_DIR}}/steering/` status:
 
 1. Load templates from `{{KIRO_DIR}}/settings/templates/steering/`
 2. Analyze codebase (JIT):
-   - `glob_file_search` for source files
-   - `read_file` for README, package.json, etc.
-   - `grep` for patterns
+   - `Glob` for source files
+   - `Read` for README, package.json, etc.
+   - `Grep` for patterns
 3. Extract patterns (not lists):
    - Product: Purpose, value, core capabilities
    - Tech: Frameworks, decisions, conventions
@@ -78,10 +78,10 @@ Document patterns and principles, not exhaustive lists.
 
 ## Tool guidance
 
-- `glob_file_search`: Find source/config files
-- `read_file`: Read steering, docs, configs
-- `grep`: Search patterns
-- `list_dir`: Analyze structure
+- `Glob`: Find source/config files
+- `Read`: Read steering, docs, configs
+- `Grep`: Search patterns
+- `LS`: Analyze structure
 
 **JIT Strategy**: Fetch when needed, not upfront.
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

The `## Tool guidance` section in `tools/cc-sdd/templates/agents/claude-code/commands/steering.md` references four tool names that do not exist in Claude Code:

| Wrong name | Correct name |
|-----------|-------------|
| `glob_file_search` | `Glob` |
| `read_file` | `Read` |
| `grep` | `Grep` |
| `list_dir` | `LS` |

The same incorrect names also appeared in the Bootstrap Flow instructions under step 2.

## Why it matters

When Claude Code agents follow this guidance and attempt to call `glob_file_search`, `read_file`, `grep`, or `list_dir`, the tool calls fail immediately because those names are not registered in Claude Code's tool registry. The steering command's core codebase-analysis functionality is broken for Claude Code users.

## Fix

Replaced all four incorrect names with their correct Claude Code equivalents (`Glob`, `Read`, `Grep`, `LS`) in both the `## Tool guidance` section and the Bootstrap Flow step 2.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->