### PR TITLE
fix: remove write-capable tools from read-only spec-status command

### DIFF
--- a/tools/cc-sdd/templates/agents/claude-code/commands/spec-status.md
+++ b/tools/cc-sdd/templates/agents/claude-code/commands/spec-status.md
@@ -1,6 +1,6 @@
 ---
 description: Show specification status and progress
-allowed-tools: Bash, Read, Glob, Write, Edit, MultiEdit, Update
+allowed-tools: Bash, Read, Glob
 argument-hint: <feature-name>
 ---
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`tools/cc-sdd/templates/agents/claude-code/commands/spec-status.md` is a read-only status command — its only purpose is to read spec files and generate a report. However, its `allowed-tools` declaration included write-capable tools:

```yaml
allowed-tools: Bash, Read, Glob, Write, Edit, MultiEdit, Update
```

Two problems:
1. **Write, Edit, MultiEdit** grant the agent permission to modify files, which is never needed for a status report command. This violates the principle of least privilege and could enable unintended side effects.
2. **`Update` is not a valid Claude Code tool name**, so including it generates a runtime warning and signals a maintenance gap.

## Fix

Reduced `allowed-tools` to only the tools actually needed by the command:

```yaml
allowed-tools: Bash, Read, Glob
```

`Bash` is retained to support the `- [ ]` / `- [x]` checkbox counting from task files. `Read` and `Glob` are needed to load spec files. No write tools are required.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->