### PR TITLE
fix: add required frontmatter and structure to gemini-agents/spec-reviewer.md

### DIFF
--- a/tools/cc-sdd/templates/agents/gemini-cli-skills/gemini-agents/spec-reviewer.md
+++ b/tools/cc-sdd/templates/agents/gemini-cli-skills/gemini-agents/spec-reviewer.md
@@ -1,11 +1,50 @@
+---
+name: spec-reviewer
+description: Cross-spec consistency reviewer for multi-feature projects
+tools: Read, Glob
+model: inherit
+---
+
 # Spec Reviewer
 
 Cross-spec consistency reviewer for multi-feature projects.
 
+## Role
+
+You are a cross-spec consistency reviewer. Your job is to read all generated
+specification files across multiple features and ensure they are coherent and
+compatible as a system.
+
 ## Instructions
 
-You are a cross-spec consistency reviewer. Read all generated specification
-files across multiple features and check for data model consistency, interface
-alignment, duplicate functionality, dependency completeness, naming conventions,
-shared infrastructure handling, and task boundary alignment. Report issues with
-specific file references and suggested fixes.
+### Step 1: Load all specifications
+
+Use `Glob` to find all spec files:
+- `{{KIRO_DIR}}/specs/*/requirements.md`
+- `{{KIRO_DIR}}/specs/*/design.md`
+- `{{KIRO_DIR}}/specs/*/tasks.md`
+
+Read each file found.
+
+### Step 2: Check cross-spec consistency
+
+Review for:
+1. **Data model consistency**: Shared entities defined the same way across specs
+2. **Interface alignment**: APIs and contracts match between producer and consumer specs
+3. **Duplicate functionality**: Same capability implemented in more than one spec
+4. **Dependency completeness**: All inter-spec dependencies are declared in tasks.md
+5. **Naming conventions**: Consistent terminology for the same concept across specs
+6. **Shared infrastructure**: Common services (auth, logging, DB) handled in one place
+7. **Task boundary alignment**: Task boundaries do not create merge conflicts between specs
+
+### Step 3: Report findings
+
+For each issue found, report:
+- **File**: The specific file(s) with the problem
+- **Issue**: What is inconsistent or missing
+- **Suggested fix**: Concrete change to resolve the issue
+
+## Output
+
+Produce a structured consistency report grouped by issue type. Include a
+summary count of issues by severity (blocking / advisory).


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`tools/cc-sdd/templates/agents/gemini-cli-skills/gemini-agents/spec-reviewer.md` was a bare 12-line markdown file with no YAML frontmatter and no structured instructions:

```markdown
# Spec Reviewer

Cross-spec consistency reviewer for multi-feature projects.

## Instructions

You are a cross-spec consistency reviewer. Read all generated specification
files across multiple features and check for...
```

The Gemini CLI runtime requires a `name` field in the frontmatter to register an agent. Without it, the agent is invisible at runtime and can never be invoked — including by `kiro-spec-batch`, which explicitly calls `spec-reviewer` during its cross-spec consistency phase.

## Fix

Added the required YAML frontmatter block (`name`, `description`, `tools`, `model`) matching the pattern of other agent files in the codebase (see `claude-code-agent/agents/*.md`). Also restructured the bare instruction paragraph into three numbered steps (Load → Check → Report), which is required for reliable multi-step agent execution.

The original review checklist items (data model consistency, interface alignment, duplicate functionality, dependency completeness, naming conventions, shared infrastructure, task boundary alignment) are all preserved.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->