### PR TITLE
fix: correct @ path separator to / in windsurf-skills AGENTS.md

### DIFF
--- a/tools/cc-sdd/templates/agents/windsurf-skills/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/windsurf-skills/docs/AGENTS.md
@@ -47,7 +47,7 @@ Project memory keeps persistent guidance (steering, specs notes, component docs)
 - Progress check: `@kiro-spec-status {feature}` (use anytime)
 
 ## Skills Structure
-Skills are located in `.windsurf/skills@kiro-*/SKILL.md`
+Skills are located in `.windsurf/skills/kiro-*/SKILL.md`
 - Each skill is a directory with a `SKILL.md` file
 - Use `/skills` to inspect currently available skills
 - Invoke a skill directly with `@kiro-<skill-name>`


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

The Skills Structure section in `tools/cc-sdd/templates/agents/windsurf-skills/docs/AGENTS.md` referenced the skill files using an `@` character as a path separator:

```
Skills are located in `.windsurf/skills@kiro-*/SKILL.md`
```

The `@` character is not a valid filesystem path separator. On any OS, the path `.windsurf/skills@kiro-*/SKILL.md` will fail to resolve — glob expansion will find no files, and skill path resolution breaks for all Windsurf users who install this template.

The equivalent path in `gemini-cli-skills/docs/GEMINI.md` uses the correct `/` separator, confirming this is a copy-paste or typo-level error specific to the windsurf-skills template.

## Fix

Changed `@` to `/`:

```
Skills are located in `.windsurf/skills/kiro-*/SKILL.md`
```

This matches the standard directory separator used everywhere else in the codebase.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->