### PR TITLE
fix: document {{DEV_GUIDELINES}} placeholder in all 7 platform docs templates

### DIFF
--- a/tools/cc-sdd/templates/agents/antigravity-skills/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/antigravity-skills/docs/AGENTS.md
@@ -25,6 +25,7 @@ Project memory keeps persistent guidance (steering, specs notes, component docs)
 - Use `/kiro-spec-status [feature-name]` to check progress
 
 ## Development Guidelines
+<!-- DEV_GUIDELINES: injected at install time with language-specific guidelines (npx cc-sdd@latest --lang <code>) -->
 {{DEV_GUIDELINES}}
 
 ## Minimal Workflow

--- a/tools/cc-sdd/templates/agents/claude-code/docs/CLAUDE.md
+++ b/tools/cc-sdd/templates/agents/claude-code/docs/CLAUDE.md
@@ -18,6 +18,7 @@ Kiro-style Spec-Driven Development on an agentic SDLC
 - Use `/kiro:spec-status [feature-name]` to check progress
 
 ## Development Guidelines
+<!-- DEV_GUIDELINES: injected at install time with language-specific guidelines (npx cc-sdd@latest --lang <code>) -->
 {{DEV_GUIDELINES}}
 
 ## Minimal Workflow

--- a/tools/cc-sdd/templates/agents/codex/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/codex/docs/AGENTS.md
@@ -25,6 +25,7 @@ Project memory keeps persistent guidance (steering, specs notes, component docs)
 - Use `/prompts:kiro-spec-status [feature-name]` to check progress
 
 ## Development Guidelines
+<!-- DEV_GUIDELINES: injected at install time with language-specific guidelines (npx cc-sdd@latest --lang <code>) -->
 {{DEV_GUIDELINES}}
 
 ## Minimal Workflow

--- a/tools/cc-sdd/templates/agents/gemini-cli-skills/docs/GEMINI.md
+++ b/tools/cc-sdd/templates/agents/gemini-cli-skills/docs/GEMINI.md
@@ -25,6 +25,7 @@ Project memory keeps persistent guidance (steering, specs notes, component docs)
 - Use `/kiro-spec-status [feature-name]` to check progress
 
 ## Development Guidelines
+<!-- DEV_GUIDELINES: injected at install time with language-specific guidelines (npx cc-sdd@latest --lang <code>) -->
 {{DEV_GUIDELINES}}
 
 ## Minimal Workflow

--- a/tools/cc-sdd/templates/agents/github-copilot/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/github-copilot/docs/AGENTS.md
@@ -18,6 +18,7 @@ Kiro-style Spec-Driven Development on an agentic SDLC
 - Use `/kiro-spec-status [feature-name]` to check progress
 
 ## Development Guidelines
+<!-- DEV_GUIDELINES: injected at install time with language-specific guidelines (npx cc-sdd@latest --lang <code>) -->
 {{DEV_GUIDELINES}}
 
 ## Minimal Workflow

--- a/tools/cc-sdd/templates/agents/windsurf-skills/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/windsurf-skills/docs/AGENTS.md
@@ -25,6 +25,7 @@ Project memory keeps persistent guidance (steering, specs notes, component docs)
 - Use `@kiro-spec-status [feature-name]` to check progress
 
 ## Development Guidelines
+<!-- DEV_GUIDELINES: injected at install time with language-specific guidelines (npx cc-sdd@latest --lang <code>) -->
 {{DEV_GUIDELINES}}
 
 ## Minimal Workflow

--- a/tools/cc-sdd/templates/agents/windsurf/docs/AGENTS.md
+++ b/tools/cc-sdd/templates/agents/windsurf/docs/AGENTS.md
@@ -18,6 +18,7 @@ Kiro-style Spec-Driven Development on an agentic SDLC
 - Use `/kiro-spec-status [feature-name]` to check progress
 
 ## Development Guidelines
+<!-- DEV_GUIDELINES: injected at install time with language-specific guidelines (npx cc-sdd@latest --lang <code>) -->
 {{DEV_GUIDELINES}}
 
 ## Minimal Workflow


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

All 7 platform docs template files contain a bare `{{DEV_GUIDELINES}}` placeholder with no explanation:

```markdown
## Development Guidelines
{{DEV_GUIDELINES}}
```

Affected files:
- `tools/cc-sdd/templates/agents/claude-code/docs/CLAUDE.md`
- `tools/cc-sdd/templates/agents/antigravity-skills/docs/AGENTS.md`
- `tools/cc-sdd/templates/agents/github-copilot/docs/AGENTS.md`
- `tools/cc-sdd/templates/agents/windsurf/docs/AGENTS.md`
- `tools/cc-sdd/templates/agents/codex/docs/AGENTS.md`
- `tools/cc-sdd/templates/agents/gemini-cli-skills/docs/GEMINI.md`
- `tools/cc-sdd/templates/agents/windsurf-skills/docs/AGENTS.md`

When contributors browse these files on GitHub, the raw `{{DEV_GUIDELINES}}` gives no indication that it is intentional — it appears broken. The Development Guidelines section looks empty, which could mislead contributors into thinking the template engine is broken or that the section was accidentally left blank.

**Note**: The install pipeline (`npx cc-sdd@latest`) correctly substitutes `{{DEV_GUIDELINES}}` with language-specific guidelines at install time (see `tools/cc-sdd/src/template/context.ts`). The template files themselves, however, are opaque about this.

## Fix

Added a one-line HTML comment above each `{{DEV_GUIDELINES}}` placeholder:

```markdown
## Development Guidelines
<!-- DEV_GUIDELINES: injected at install time with language-specific guidelines (npx cc-sdd@latest --lang <code>) -->
{{DEV_GUIDELINES}}
```

This change:
- Makes the template intent self-documenting for GitHub browsers
- Does **not** affect the install pipeline — `{{DEV_GUIDELINES}}` is still found and replaced
- Adds no new behavior, only documentation

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->