### PR TITLE
fix(cc-sdd): tighten remaining NLPM audit fixes

### DIFF
--- a/tools/cc-sdd/templates/agents/claude-code/commands/spec-status.md
+++ b/tools/cc-sdd/templates/agents/claude-code/commands/spec-status.md
@@ -1,6 +1,6 @@
 ---
 description: Show specification status and progress
-allowed-tools: Bash, Read, Glob, Write, Edit, MultiEdit, Update
+allowed-tools: Read, Glob
 argument-hint: <feature-name>
 ---
 

--- a/tools/cc-sdd/templates/agents/gemini-cli-skills/gemini-agents/spec-reviewer.md
+++ b/tools/cc-sdd/templates/agents/gemini-cli-skills/gemini-agents/spec-reviewer.md
@@ -1,11 +1,52 @@
+---
+name: spec-reviewer
+description: Cross-spec consistency reviewer for multi-feature projects
+tools:
+  - read_file
+  - glob
+model: inherit
+---
+
 # Spec Reviewer
 
 Cross-spec consistency reviewer for multi-feature projects.
 
+## Role
+
+You are a cross-spec consistency reviewer. Your job is to read all generated
+specification files across multiple features and ensure they are coherent and
+compatible as a system.
+
 ## Instructions
 
-You are a cross-spec consistency reviewer. Read all generated specification
-files across multiple features and check for data model consistency, interface
-alignment, duplicate functionality, dependency completeness, naming conventions,
-shared infrastructure handling, and task boundary alignment. Report issues with
-specific file references and suggested fixes.
+### Step 1: Load all specifications
+
+Use `glob` to find all spec files:
+- `{{KIRO_DIR}}/specs/*/requirements.md`
+- `{{KIRO_DIR}}/specs/*/design.md`
+- `{{KIRO_DIR}}/specs/*/tasks.md`
+
+Use `read_file` to read each file found.
+
+### Step 2: Check cross-spec consistency
+
+Review for:
+1. **Data model consistency**: Shared entities defined the same way across specs
+2. **Interface alignment**: APIs and contracts match between producer and consumer specs
+3. **Duplicate functionality**: Same capability implemented in more than one spec
+4. **Dependency completeness**: All inter-spec dependencies are declared in tasks.md
+5. **Naming conventions**: Consistent terminology for the same concept across specs
+6. **Shared infrastructure**: Common services (auth, logging, DB) handled in one place
+7. **Task boundary alignment**: Task boundaries do not create merge conflicts between specs
+
+### Step 3: Report findings
+
+For each issue found, report:
+- **File**: The specific file(s) with the problem
+- **Issue**: What is inconsistent or missing
+- **Suggested fix**: Concrete change to resolve the issue
+
+## Output
+
+Produce a structured consistency report grouped by issue type. Include a
+summary count of issues by severity (blocking / advisory).

--- a/tools/cc-sdd/test/realManifestGeminiCliSkills.test.ts
+++ b/tools/cc-sdd/test/realManifestGeminiCliSkills.test.ts
@@ -96,6 +96,11 @@ describe('real gemini-cli-skills manifest', () => {
     // Gemini-specific: agents directory
     const geminiAgent = join(cwd, '.gemini/agents/spec-reviewer.md');
     expect(await exists(geminiAgent)).toBe(true);
+    const geminiAgentText = await readFile(geminiAgent, 'utf8');
+    expect(geminiAgentText).toMatch(/^---\nname: spec-reviewer\n/);
+    expect(geminiAgentText).toContain('tools:\n  - read_file\n  - glob\n');
+    expect(geminiAgentText).toContain('Use `glob` to find all spec files');
+    expect(geminiAgentText).toContain('Use `read_file` to read each file found');
 
     const skillSpecDesign = join(cwd, '.gemini/skills/kiro-spec-design/SKILL.md');
     expect(await exists(skillSpecDesign)).toBe(true);


### PR DESCRIPTION
## Summary
- replace #167 with a stricter least-privilege Claude Code spec-status command (`Read, Glob` only)
- replace #168 with a Gemini CLI-compatible spec-reviewer agent frontmatter using YAML array tool names (`read_file`, `glob`)
- keep the cross-spec reviewer instructions structured without adding write or shell permissions

## Verification
- npm test -- test/realManifestGeminiCliSkills.test.ts test/realManifestClaudeCodeSkills.test.ts
- npm test

Closes #167
Closes #168