### PR TITLE
chore: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,25 @@ Skills are located under the agent-specific skills directory (e.g., `.claude/ski
 - Load entire `.kiro/steering/` as project memory
 - Default files: `product.md`, `tech.md`, `structure.md`
 - Custom files are supported (managed via `/kiro-steering-custom`)
+
+## Cursor Cloud specific instructions
+
+The sole buildable/testable package lives in `tools/cc-sdd/`. There are no external services, databases, or Docker containers.
+
+### Quick reference
+
+| Action | Command (from `tools/cc-sdd/`) |
+|---|---|
+| Install deps + build | `npm ci` (runs `prepare` → `tsc`) |
+| Type-check (lint) | `npx tsc --noEmit` |
+| Run all tests | `npm test` (vitest) |
+| Watch tests | `npm run test:watch` |
+| Build only | `npm run build` |
+| Run CLI | `node dist/cli.js [flags]` |
+
+### Notes
+
+- No dedicated linter (ESLint/Biome) is configured; `tsc --noEmit` with `strict: true` serves as the lint step.
+- `npm ci` automatically triggers `prepare` → `npm run build` → `tsc` + shebang injection, so a separate build step is not needed after install.
+- The CLI is a one-shot scaffolding tool (not a long-running server). Test it by running `node dist/cli.js --cursor-skills --lang en --dry-run` or with `-y` to write files to a temp directory.
+- All 39 test files are pure unit/integration tests via Vitest — no network, no filesystem side effects outside temp dirs.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with a quick-reference table for common dev commands and notes about how the project builds/tests/runs.

### What changed
- `AGENTS.md`: Added cloud-agent-specific section covering build, test, type-check, and CLI run commands, plus non-obvious notes (no ESLint, `npm ci` auto-builds, CLI is one-shot, tests are pure unit/integration).

### Evidence

Dev environment setup log showing all checks passing:
[dev_env_setup.log](https://cursor.com/agents/bc-20d7eabd-2b0d-4288-81b8-4703681beec8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_env_setup.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20d7eabd-2b0d-4288-81b8-4703681beec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20d7eabd-2b0d-4288-81b8-4703681beec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

