### PR TITLE
docs: add Cursor Cloud specific dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,24 @@ Skills are located under the agent-specific skills directory (e.g., `.claude/ski
 - Load entire `.kiro/steering/` as project memory
 - Default files: `product.md`, `tech.md`, `structure.md`
 - Custom files are supported (managed via `/kiro-steering-custom`)
+
+## Cursor Cloud specific instructions
+
+### Project layout
+- The publishable package lives at `tools/cc-sdd/` (TypeScript CLI, zero runtime dependencies).
+- The repo root contains docs, assets, specs, and CI config but no runnable code outside `tools/cc-sdd/`.
+
+### Development commands (all run from `tools/cc-sdd/`)
+| Task | Command |
+|------|---------|
+| Install deps | `npm ci` |
+| Build | `npm run build` |
+| Test | `npm test` (Vitest) |
+| Type check | `npx tsc --noEmit` |
+| Run CLI | `node dist/cli.js [options]` |
+
+### Notes
+- `npm ci` triggers the `prepare` script which runs the build automatically, so after install the `dist/` directory is ready.
+- There is no dedicated lint tool (ESLint/Biome); TypeScript strict mode (`tsc --noEmit`) serves as the lint check.
+- The CLI is a pure file-generation tool with no long-running server, background process, or external service dependency.
+- Tests are fast (~2 s) and fully self-contained; no fixtures, env vars, or network required.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with development commands, project layout notes, and non-obvious caveats for future cloud agents.

## Changes
- Added development command table (install, build, test, type check, run CLI)
- Documented that `npm ci` auto-builds via the `prepare` script
- Noted absence of a dedicated linter (TypeScript strict mode serves as lint)
- Clarified the CLI is a pure file-generation tool with no external dependencies

## Evidence of working environment

Test output (193/193 tests pass):
[test_output.log](https://cursor.com/agents/bc-d466488d-adab-4d4f-8c95-a99ca4e4f463/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_output.log)

CLI install demo output:
[cli_install_demo.log](https://cursor.com/agents/bc-d466488d-adab-4d4f-8c95-a99ca4e4f463/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli_install_demo.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d466488d-adab-4d4f-8c95-a99ca4e4f463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d466488d-adab-4d4f-8c95-a99ca4e4f463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

