### PR TITLE
docs: add Autohand Code manual install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,25 @@ npx cc-sdd@latest --dry-run
 npx cc-sdd@latest --kiro-dir docs
 ```
 
+### Autohand Code (manual)
+
+cc-sdd does not currently ship a native Autohand installer target. Autohand Code can still read the existing Agent Skills templates if you copy complete skill folders into its skills directory:
+
+```bash
+git clone https://github.com/gotalab/cc-sdd.git
+cd cc-sdd
+
+# Global install
+mkdir -p ~/.autohand/skills/
+cp -R tools/cc-sdd/templates/agents/codex-skills/skills/kiro-* ~/.autohand/skills/
+
+# Project-level install
+mkdir -p .autohand/skills/
+cp -R tools/cc-sdd/templates/agents/codex-skills/skills/kiro-* .autohand/skills/
+```
+
+Autohand Code also supports `autohand --skill-install` for cataloged skills, with `--project` for workspace-level installs. Until cc-sdd is listed there, use the direct copy path above.
+
 ## Customization
 
 Edit templates and rules in `{{KIRO_DIR}}/settings/` to match your team's workflow.


### PR DESCRIPTION
## Summary

Adds a conservative Autohand Code manual install note to the root README.

The new section documents how Autohand Code users can copy the existing skills-mode templates into:

- `~/.autohand/skills/` for global installs
- `.autohand/skills/` for project-level installs

It does not claim cc-sdd has a native Autohand installer target. It also keeps `autohand --skill-install` wording limited to cataloged skills, since cc-sdd is not currently listed there.

## Validation

- `git diff --check`
- `npm test` from `tools/cc-sdd`