### PR TITLE
feat(cc-sdd): add Vietnamese (vi) language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Add Vietnamese (vi) language support, bringing total to 14 languages
+
 ## [3.0.2] - 2026-04-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npx cc-sdd@latest --codex-skills --lang ja      # Codex, Japanese
 npx cc-sdd@latest --cursor-skills --lang zh-TW  # Cursor IDE, Traditional Chinese
 ```
 
-Supports 8 AI coding agents (Claude Code and Codex stable; Cursor, Copilot, Windsurf, OpenCode, Gemini CLI, and Antigravity in beta) and 13 languages. See [Supported Agents](#supported-agents) for the full list.
+Supports 8 AI coding agents (Claude Code and Codex stable; Cursor, Copilot, Windsurf, OpenCode, Gemini CLI, and Antigravity in beta) and 14 languages. See [Supported Agents](#supported-agents) for the full list.
 
 Then, in your agent:
 
@@ -156,7 +156,7 @@ npx cc-sdd@latest --qwen           # Qwen Code
 npx cc-sdd@latest --lang ja        # Japanese
 npx cc-sdd@latest --lang zh-TW     # Traditional Chinese
 npx cc-sdd@latest --lang es        # Spanish
-# Supports: en, ja, zh-TW, zh, es, pt, de, fr, ru, it, ko, ar, el
+# Supports: en, ja, zh-TW, zh, es, pt, de, fr, ru, it, ko, ar, el, vi
 ```
 
 ### Advanced options

--- a/tools/cc-sdd/README.md
+++ b/tools/cc-sdd/README.md
@@ -50,7 +50,7 @@ npx cc-sdd@latest --codex-skills --lang ja      # Codex, Japanese
 npx cc-sdd@latest --cursor-skills --lang zh-TW  # Cursor IDE, Traditional Chinese
 ```
 
-Supports 8 AI coding agents (Claude Code and Codex stable; Cursor, Copilot, Windsurf, OpenCode, Gemini CLI, and Antigravity in beta) and 13 languages. See [Supported Agents](#supported-agents) for the full list.
+Supports 8 AI coding agents (Claude Code and Codex stable; Cursor, Copilot, Windsurf, OpenCode, Gemini CLI, and Antigravity in beta) and 14 languages. See [Supported Agents](#supported-agents) for the full list.
 
 Then, in your agent:
 
@@ -122,7 +122,7 @@ All 8 skills variants ship the same 17-skill set. The difference is how much rea
 npx cc-sdd@latest --lang ja    # Japanese
 npx cc-sdd@latest --lang zh-TW # Traditional Chinese
 npx cc-sdd@latest --lang es    # Spanish
-# Supports: en, ja, zh-TW, zh, es, pt, de, fr, ru, it, ko, ar, el
+# Supports: en, ja, zh-TW, zh, es, pt, de, fr, ru, it, ko, ar, el, vi
 ```
 
 ### Legacy modes (deprecated)

--- a/tools/cc-sdd/README_ja.md
+++ b/tools/cc-sdd/README_ja.md
@@ -50,7 +50,7 @@ npx cc-sdd@latest --codex-skills --lang ja      # Codex、日本語
 npx cc-sdd@latest --cursor-skills --lang zh-TW  # Cursor IDE、繁体字中国語
 ```
 
-8 つの AI coding agent（Claude Code と Codex は stable、Cursor, Copilot, Windsurf, OpenCode, Gemini CLI, Antigravity は beta）と 13 言語に対応。全リストは [対応エージェント](#対応エージェント) を参照。
+8 つの AI coding agent（Claude Code と Codex は stable、Cursor, Copilot, Windsurf, OpenCode, Gemini CLI, Antigravity は beta）と 14 言語に対応。全リストは [対応エージェント](#対応エージェント) を参照。
 
 その後、エージェント上で:
 
@@ -122,7 +122,7 @@ spec フェーズの典型的な出力（10 分以内）:
 npx cc-sdd@latest --lang ja    # 日本語
 npx cc-sdd@latest --lang zh-TW # 繁体字中国語
 npx cc-sdd@latest --lang es    # スペイン語
-# 対応言語: en, ja, zh-TW, zh, es, pt, de, fr, ru, it, ko, ar, el
+# 対応言語: en, ja, zh-TW, zh, es, pt, de, fr, ru, it, ko, ar, el, vi
 ```
 
 ### レガシーモード（非推奨）

--- a/tools/cc-sdd/README_zh-TW.md
+++ b/tools/cc-sdd/README_zh-TW.md
@@ -50,7 +50,7 @@ npx cc-sdd@latest --codex-skills --lang ja      # Codex, 日語
 npx cc-sdd@latest --cursor-skills --lang zh-TW  # Cursor IDE, 繁體中文
 ```
 
-支援 8 個 AI coding agent（Claude Code 與 Codex 為 stable；Cursor, Copilot, Windsurf, OpenCode, Gemini CLI, Antigravity 為 beta）和 13 種語言。完整列表請參考 [支援的代理](#支援的代理)。
+支援 8 個 AI coding agent（Claude Code 與 Codex 為 stable；Cursor, Copilot, Windsurf, OpenCode, Gemini CLI, Antigravity 為 beta）和 14 種語言。完整列表請參考 [支援的代理](#支援的代理)。
 
 然後在你的代理裡執行:
 
@@ -122,7 +122,7 @@ spec 階段的典型產出（10 分鐘以內）:
 npx cc-sdd@latest --lang zh-TW # 繁體中文
 npx cc-sdd@latest --lang ja    # 日語
 npx cc-sdd@latest --lang es    # 西班牙語
-# 支援語言: en, ja, zh-TW, zh, es, pt, de, fr, ru, it, ko, ar, el
+# 支援語言: en, ja, zh-TW, zh, es, pt, de, fr, ru, it, ko, ar, el, vi
 ```
 
 ### 舊版模式（已棄用）

--- a/tools/cc-sdd/src/constants/languages.ts
+++ b/tools/cc-sdd/src/constants/languages.ts
@@ -12,6 +12,7 @@ export const supportedLanguages = [
   'ko',
   'ar',
   'el',
+  'vi',
 ] as const;
 
 export type SupportedLanguage = (typeof supportedLanguages)[number];

--- a/tools/cc-sdd/src/index.ts
+++ b/tools/cc-sdd/src/index.ts
@@ -28,7 +28,7 @@ const helpText = `Usage: cc-sdd [options]
 
 Options:
   --agent <${agentKeys.join('|')}>  Select agent
-${agentAliasLine}  --lang <ja|en|zh-TW|zh|es|pt|de|fr|ru|it|ko|ar|el>  Language
+${agentAliasLine}  --lang <ja|en|zh-TW|zh|es|pt|de|fr|ru|it|ko|ar|el|vi>  Language
   --os <auto|mac|windows|linux>               Target OS (auto uses runtime)
   --kiro-dir <path>                           Kiro root dir (default .kiro)
   --overwrite <prompt|skip|force>             Overwrite policy (default: prompt)

--- a/tools/cc-sdd/src/template/context.ts
+++ b/tools/cc-sdd/src/template/context.ts
@@ -33,6 +33,7 @@ const guidelinesMap: Record<SupportedLanguage, string> = {
   ko: '- Think in English, generate responses in Korean. All Markdown content written to project files (e.g., requirements.md, design.md, tasks.md, research.md, validation reports) MUST be written in the target language configured for this specification (see spec.json.language).',
   ar: '- Think in English, generate responses in Arabic. All Markdown content written to project files (e.g., requirements.md, design.md, tasks.md, research.md, validation reports) MUST be written in the target language configured for this specification (see spec.json.language).',
   el: '- Think in English, generate responses in Greek. All Markdown content written to project files (e.g., requirements.md, design.md, tasks.md, research.md, validation reports) MUST be written in the target language configured for this specification (see spec.json.language).',
+  vi: '- Think in English, generate responses in Vietnamese. All Markdown content written to project files (e.g., requirements.md, design.md, tasks.md, research.md, validation reports) MUST be written in the target language configured for this specification (see spec.json.language).',
 };
 
 export const getDevGuidelines = (lang: SupportedLanguage): string => guidelinesMap[lang];

--- a/tools/cc-sdd/test/args.test.ts
+++ b/tools/cc-sdd/test/args.test.ts
@@ -29,6 +29,7 @@ describe('parseArgs', () => {
   it('parses additional languages', () => {
     expect(parseArgs(['--lang', 'es']).lang).toBe('es');
     expect(parseArgs(['--lang', 'ko']).lang).toBe('ko');
+    expect(parseArgs(['--lang', 'vi']).lang).toBe('vi');
   });
 
   it('parses backup with and without value', () => {

--- a/tools/cc-sdd/test/templateContext.test.ts
+++ b/tools/cc-sdd/test/templateContext.test.ts
@@ -44,8 +44,16 @@ describe('buildTemplateContext', () => {
     expect(ctx.AGENT_DOC).toBe('CLAUDE.md');
   });
 
+  it('provides Vietnamese guidelines', () => {
+    const ctx = buildTemplateContext({ agent: 'claude-code', lang: 'vi' });
+    expect(ctx.LANG_CODE).toBe('vi');
+    expect(ctx.DEV_GUIDELINES).toBe(
+      '- Think in English, generate responses in Vietnamese. All Markdown content written to project files (e.g., requirements.md, design.md, tasks.md, research.md, validation reports) MUST be written in the target language configured for this specification (see spec.json.language).',
+    );
+  });
+
   it('provides guidelines for all supported languages', () => {
-    const langs = ['en', 'ja', 'zh-TW', 'zh', 'es', 'pt', 'de', 'fr', 'ru', 'it', 'ko', 'ar', 'el'] as const;
+    const langs = ['en', 'ja', 'zh-TW', 'zh', 'es', 'pt', 'de', 'fr', 'ru', 'it', 'ko', 'ar', 'el', 'vi'] as const;
     for (const lang of langs) {
       const ctx = buildTemplateContext({ agent: 'claude-code', lang });
       expect(ctx.DEV_GUIDELINES.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

Adds Vietnamese (`vi`) as the 14th supported language, following the same pattern as the Greek (`el`) addition (#121):

- Add `vi` to `supportedLanguages` in `tools/cc-sdd/src/constants/languages.ts` (CLI `--lang vi` validation flows from this constant)
- Add the Vietnamese dev-guidelines entry to `guidelinesMap` in `tools/cc-sdd/src/template/context.ts` ("Think in English, generate responses in Vietnamese…")
- List `vi` in the `--lang` help text in `tools/cc-sdd/src/index.ts`
- Update language count (13 → 14) and supported-language lists in the root README and `tools/cc-sdd` READMEs (en / ja / zh-TW)
- Add a CHANGELOG entry under `[Unreleased]`

## Tests

- New test: `buildTemplateContext` returns the exact Vietnamese guidelines for `lang: 'vi'`
- Extended: all-languages guidelines coverage and `parseArgs(['--lang', 'vi'])` acceptance
- Full suite: 39 files, 194/194 passing; `tsc` build clean
- E2E: ran the built CLI with `--claude-skills --lang vi` in a scratch dir — generated `CLAUDE.md` contains the Vietnamese guideline, and the language propagates into skills and `.kiro/settings/templates/specs/init.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)