### PR TITLE
Recommend MiniMax-M3 for compatible agents

### DIFF
--- a/tools/cc-sdd/src/agents/registry.ts
+++ b/tools/cc-sdd/src/agents/registry.ts
@@ -37,7 +37,11 @@ export const agentDefinitions = {
     description:
       'Installs kiro prompts in `.claude/commands/kiro/`, shared settings in `{{KIRO_DIR}}/settings/` (default `.kiro/settings/`), and an AGENTS.md quickstart.',
     aliasFlags: ['--claude-code', '--claude'],
-    recommendedModels: ['Planning / review: Claude Opus 4.6 or newer', 'Implementation: Claude Sonnet 4.6 or newer'],
+    recommendedModels: [
+      'Planning / review: Claude Opus 4.6 or newer',
+      'Implementation: Claude Sonnet 4.6 or newer',
+      'MiniMax-M3',
+    ],
     layout: {
       commandsDir: '.claude/commands/kiro',
       agentDir: '.claude',
@@ -59,7 +63,11 @@ export const agentDefinitions = {
     description:
       'Installs kiro prompts in `.claude/commands/kiro/`, a Claude agent library in `.claude/agents/kiro/`, shared settings in `{{KIRO_DIR}}/settings/`, and a CLAUDE.md quickstart.',
     aliasFlags: ['--claude-code-agent', '--claude-agent'],
-    recommendedModels: ['Planning / review: Claude Opus 4.6 or newer', 'Implementation: Claude Sonnet 4.6 or newer'],
+    recommendedModels: [
+      'Planning / review: Claude Opus 4.6 or newer',
+      'Implementation: Claude Sonnet 4.6 or newer',
+      'MiniMax-M3',
+    ],
     layout: {
       commandsDir: '.claude/commands/kiro',
       agentDir: '.claude',
@@ -81,7 +89,11 @@ export const agentDefinitions = {
     description:
       'Installs kiro skills in `.claude/skills/kiro-*/`, shared settings in `{{KIRO_DIR}}/settings/`, and a CLAUDE.md quickstart.',
     aliasFlags: ['--claude-code-skills', '--claude-skills'],
-    recommendedModels: ['Planning / review: Claude Opus 4.6 or newer', 'Implementation: Claude Sonnet 4.6 or newer'],
+    recommendedModels: [
+      'Planning / review: Claude Opus 4.6 or newer',
+      'Implementation: Claude Sonnet 4.6 or newer',
+      'MiniMax-M3',
+    ],
     layout: {
       commandsDir: '.claude/skills',
       agentDir: '.claude',
@@ -352,7 +364,7 @@ export const agentDefinitions = {
     description:
       'Installs kiro prompts in `.opencode/commands/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--opencode'],
-    recommendedModels: ['Planning / review: gpt-5.4 high or xhigh', 'Implementation: gpt-5.4'],
+    recommendedModels: ['Planning / review: gpt-5.4 high or xhigh', 'Implementation: gpt-5.4', 'MiniMax-M3'],
     layout: {
       commandsDir: '.opencode/commands',
       agentDir: '.opencode',
@@ -371,7 +383,7 @@ export const agentDefinitions = {
     description:
       'Installs kiro commands in `.opencode/commands/`, a kiro agent library in `.opencode/agents/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--opencode-agent'],
-    recommendedModels: ['Planning / review: gpt-5.4 high or xhigh', 'Implementation: gpt-5.4'],
+    recommendedModels: ['Planning / review: gpt-5.4 high or xhigh', 'Implementation: gpt-5.4', 'MiniMax-M3'],
     layout: {
       commandsDir: '.opencode/commands',
       agentDir: '.opencode',
@@ -393,7 +405,7 @@ export const agentDefinitions = {
     description:
       'Installs kiro skills in `.opencode/skills/kiro-*/`, shared settings in `{{KIRO_DIR}}/settings/`, and an AGENTS.md quickstart.',
     aliasFlags: ['--opencode-skills'],
-    recommendedModels: ['Planning / review: gpt-5.4 high or xhigh', 'Implementation: gpt-5.4'],
+    recommendedModels: ['Planning / review: gpt-5.4 high or xhigh', 'Implementation: gpt-5.4', 'MiniMax-M3'],
     layout: {
       commandsDir: '.opencode/skills',
       agentDir: '.opencode',


### PR DESCRIPTION
Reason: Add MiniMax-M3 to compatible agent model recommendations.

## Summary

- Add MiniMax-M3 to the recommendation lists for every compatible agent mode.
- Leave unrelated agent definitions and templates unchanged.

## Checks

- `npm test`
- `npm run build`
- Compiled registry assertion for all six updated modes
